### PR TITLE
Only handle enabled collections/taxonomies

### DIFF
--- a/src/Subscribers/ContentDefaultsSubscriber.php
+++ b/src/Subscribers/ContentDefaultsSubscriber.php
@@ -34,6 +34,11 @@ class ContentDefaultsSubscriber
         $handle = $property->handle();
         $sites = $property->sites();
 
+        // Abort if Collection or Taxnomy was disabled in the config.
+        if (in_array($handle, config("advanced-seo.disabled.{$type}", []))) {
+            return;
+        }
+
         Seo::findOrMake($type, $handle)->createOrDeleteLocalizations($sites);
     }
 


### PR DESCRIPTION
We don't want to create/delete localizations of collection/taxonomy defaults if the collection/taxonomy has been disabled in the config.