### PR TITLE
Always set a social images theme

### DIFF
--- a/src/Fields/OnPageSeoFields.php
+++ b/src/Fields/OnPageSeoFields.php
@@ -112,10 +112,17 @@ class OnPageSeoFields extends BaseFields
                     ],
                 ],
             ],
+            [
+                'handle' => 'seo_social_images_theme',
+                'field' => [
+                    'type' => 'hidden',
+                    'default' => SocialImageTheme::fieldtypeDefault(),
+                ],
+            ],
         ]);
 
         if (SocialImageTheme::all()->count() > 1) {
-            $fields->push([
+            $fields->put(2, [
                 'handle' => 'seo_social_images_theme',
                 'field' => [
                     'display' => 'Theme',
@@ -425,7 +432,7 @@ class OnPageSeoFields extends BaseFields
                     'field' => [
                         'type' => 'button_group',
                         'options' => [
-                            'current' => 'Current ' . ucfirst(str_singular($this->typePlaceholder())),
+                            'current' => 'Current '.ucfirst(str_singular($this->typePlaceholder())),
                             'other' => 'Other Entry',
                             'custom' => 'Custom URL',
                         ],

--- a/src/SocialImages/SocialImage.php
+++ b/src/SocialImages/SocialImage.php
@@ -3,6 +3,7 @@
 namespace Aerni\AdvancedSeo\SocialImages;
 
 use Aerni\AdvancedSeo\Facades\SocialImage as SocialImageApi;
+use Aerni\AdvancedSeo\Models\SocialImageTheme;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Spatie\Browsershot\Browsershot;
@@ -60,8 +61,8 @@ class SocialImage
 
     protected function templateUrl(): string
     {
-        return url('/') . SocialImageApi::route(
-            theme: $this->entry->seo_social_images_theme,
+        return url('/').SocialImageApi::route(
+            theme: $this->entry->seo_social_images_theme ?? SocialImageTheme::fieldtypeDefault(),
             type: $this->model['type'],
             id: $this->entry->id,
         );


### PR DESCRIPTION
This PR prevents an error if there is no social images theme saved on the content. We simply fall back to the default theme and also add a hidden field if there is only one theme.