### PR TITLE
Add alternates for collection taxonomy pages

### DIFF
--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -361,13 +361,14 @@ class Cascade
             return null;
         }
 
-        /*
-        TODO: Support collection term show page.
-        Return if we're on a collection term show page.
-        Statamic has yet to provide a way to get the URLs of collection terms.
-        */
+        // Handles collection taxonomy show page.
         if ($this->context->has('segment_3') && $this->context->value('is_term') === true) {
-            return null;
+            $localizedTerm = $this->context->get('title')->augmentable();
+
+            return $localizedTerm->taxonomy()->sites()
+                ->map(fn ($locale) => [
+                    'url' => $localizedTerm->in($locale)->absoluteUrl(),
+                    'locale' => Helpers::parseLocale(Site::get($locale)->locale()),
         }
 
         // Handles taxonomy index page.


### PR DESCRIPTION
This PR closes #28. Advanced SEO can now correctly output alternate links for collection taxonomy index and show pages like:

```
https://site.com/collection/taxonomy
https://site.com/collection/taxonomy/term
```