### PR TITLE
Add more control over site name position

### DIFF
--- a/content/content.yaml
+++ b/content/content.yaml
@@ -1,3 +1,4 @@
+seo_site_name_position: end
 seo_generate_social_images: false
 seo_twitter_card: summary
 seo_canonical_type: current

--- a/content/general.yaml
+++ b/content/general.yaml
@@ -1,4 +1,3 @@
 title_separator: '|'
-title_position: before
 site_json_ld_type: none
 use_breadcrumbs: true

--- a/resources/lang/en/fields.php
+++ b/resources/lang/en/fields.php
@@ -9,6 +9,11 @@ return [
         'default_instructions' => 'Configure the default title and description of your :type.',
     ],
 
+    'seo_site_name_position' => [
+        'instructions' => 'Set the site name position for the meta title of this :type.',
+        'default_instructions' => 'Set the default site name position for the meta title of your :type.',
+    ],
+
     'seo_title' => [
         'instructions' => 'Set the meta title of this :type.',
         'default_instructions' => 'Set the default meta title of your :type.',

--- a/src/Fields/ContentDefaultsFields.php
+++ b/src/Fields/ContentDefaultsFields.php
@@ -36,22 +36,6 @@ class ContentDefaultsFields extends BaseFields
                 ],
             ],
             [
-                'handle' => 'seo_site_name_position',
-                'field' => [
-                    'type' => 'button_group',
-                    'display' => 'Site Name Position',
-                    'instructions' => $this->trans('seo_site_name_position', 'default_instructions'),
-                    'options' => [
-                        'end' => 'End',
-                        'start' => 'Start',
-                        'disabled' => 'Disabled',
-                    ],
-                    'default' => Defaults::data('collections')->get('seo_site_name_position'),
-                    'localizable' => true,
-                    'listable' => false,
-                ],
-            ],
-            [
                 'handle' => 'seo_title',
                 'field' => [
                     'type' => 'text',
@@ -73,6 +57,22 @@ class ContentDefaultsFields extends BaseFields
                     'localizable' => true,
                     'listable' => 'hidden',
                     'character_limit' => 160,
+                ],
+            ],
+            [
+                'handle' => 'seo_site_name_position',
+                'field' => [
+                    'type' => 'button_group',
+                    'display' => 'Site Name Position',
+                    'instructions' => $this->trans('seo_site_name_position', 'default_instructions'),
+                    'options' => [
+                        'end' => 'End',
+                        'start' => 'Start',
+                        'disabled' => 'Disabled',
+                    ],
+                    'default' => Defaults::data('collections')->get('seo_site_name_position'),
+                    'localizable' => true,
+                    'listable' => false,
                 ],
             ],
         ];

--- a/src/Fields/ContentDefaultsFields.php
+++ b/src/Fields/ContentDefaultsFields.php
@@ -36,6 +36,22 @@ class ContentDefaultsFields extends BaseFields
                 ],
             ],
             [
+                'handle' => 'seo_site_name_position',
+                'field' => [
+                    'type' => 'button_group',
+                    'display' => 'Site Name Position',
+                    'instructions' => $this->trans('seo_site_name_position', 'default_instructions'),
+                    'options' => [
+                        'end' => 'End',
+                        'start' => 'Start',
+                        'disabled' => 'Disabled',
+                    ],
+                    'default' => Defaults::data('collections')->get('seo_site_name_position'),
+                    'localizable' => true,
+                    'listable' => false,
+                ],
+            ],
+            [
                 'handle' => 'seo_title',
                 'field' => [
                     'type' => 'text',

--- a/src/Fields/GeneralFields.php
+++ b/src/Fields/GeneralFields.php
@@ -66,22 +66,6 @@ class GeneralFields extends BaseFields
                 ],
             ],
             [
-                'handle' => 'title_position',
-                'field' => [
-                    'options' => [
-                        'before' => 'Before',
-                        'after' => 'After',
-                    ],
-                    'default' => Defaults::data('site::general')->get('title_position'),
-                    'localizable' => true,
-                    'type' => 'button_group',
-                    'instructions' => 'Display the meta title before or after the site name.',
-                    'listable' => false,
-                    'display' => 'Title Position',
-                    'width' => 50,
-                ],
-            ],
-            [
                 'handle' => 'section_knowledge_graph',
                 'field' => [
                     'type' => 'section',

--- a/src/Fields/GeneralFields.php
+++ b/src/Fields/GeneralFields.php
@@ -36,6 +36,7 @@ class GeneralFields extends BaseFields
                     'listable' => 'hidden',
                     'display' => 'Site Name',
                     'instructions' => 'The site name is added to your meta titles.',
+                    'width' => 50,
                 ],
             ],
             [
@@ -57,7 +58,7 @@ class GeneralFields extends BaseFields
                     'push_tags' => false,
                     'cast_booleans' => false,
                     'type' => 'select',
-                    'instructions' => 'The separator between the site name and meta title.',
+                    'instructions' => 'This separates the site name and page title.',
                     'width' => 50,
                     'listable' => 'hidden',
                     'display' => 'Title Separator',

--- a/src/Fields/OnPageSeoFields.php
+++ b/src/Fields/OnPageSeoFields.php
@@ -37,6 +37,25 @@ class OnPageSeoFields extends BaseFields
                 ],
             ],
             [
+                'handle' => 'seo_site_name_position',
+                'field' => [
+                    'display' => 'Site Name Position',
+                    'instructions' => $this->trans('seo_site_name_position', 'instructions'),
+                    'type' => 'seo_source',
+                    'default' => '@default',
+                    'localizable' => true,
+                    'classes' => 'button_group-fieldtype',
+                    'field' => [
+                        'type' => 'button_group',
+                        'options' => [
+                            'end' => 'End',
+                            'start' => 'Start',
+                            'disabled' => 'Disabled',
+                        ],
+                    ],
+                ],
+            ],
+            [
                 'handle' => 'seo_title',
                 'field' => [
                     'display' => 'Meta Title',

--- a/src/Fields/OnPageSeoFields.php
+++ b/src/Fields/OnPageSeoFields.php
@@ -37,25 +37,6 @@ class OnPageSeoFields extends BaseFields
                 ],
             ],
             [
-                'handle' => 'seo_site_name_position',
-                'field' => [
-                    'display' => 'Site Name Position',
-                    'instructions' => $this->trans('seo_site_name_position', 'instructions'),
-                    'type' => 'seo_source',
-                    'default' => '@default',
-                    'localizable' => true,
-                    'classes' => 'button_group-fieldtype',
-                    'field' => [
-                        'type' => 'button_group',
-                        'options' => [
-                            'end' => 'End',
-                            'start' => 'Start',
-                            'disabled' => 'Disabled',
-                        ],
-                    ],
-                ],
-            ],
-            [
                 'handle' => 'seo_title',
                 'field' => [
                     'display' => 'Meta Title',
@@ -84,6 +65,25 @@ class OnPageSeoFields extends BaseFields
                     'field' => [
                         'type' => 'textarea',
                         'character_limit' => 160,
+                    ],
+                ],
+            ],
+            [
+                'handle' => 'seo_site_name_position',
+                'field' => [
+                    'display' => 'Site Name Position',
+                    'instructions' => $this->trans('seo_site_name_position', 'instructions'),
+                    'type' => 'seo_source',
+                    'default' => '@default',
+                    'localizable' => true,
+                    'classes' => 'button_group-fieldtype',
+                    'field' => [
+                        'type' => 'button_group',
+                        'options' => [
+                            'end' => 'End',
+                            'start' => 'Start',
+                            'disabled' => 'Disabled',
+                        ],
                     ],
                 ],
             ],

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -44,6 +44,7 @@ class ServiceProvider extends AddonServiceProvider
 
     protected $updateScripts = [
         Updates\CreateSocialImagesTheme::class,
+        Updates\MigrateSiteNamePosition::class,
     ];
 
     protected $routes = [

--- a/src/Updates/MigrateSiteNamePosition.php
+++ b/src/Updates/MigrateSiteNamePosition.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Aerni\AdvancedSeo\Updates;
+
+use Aerni\AdvancedSeo\Facades\Seo;
+use Statamic\UpdateScripts\UpdateScript;
+use Statamic\Facades\Site;
+use Illuminate\Support\Arr;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Term;
+
+class MigrateSiteNamePosition extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('1.3.0');
+    }
+
+    public function update()
+    {
+        // The mapping of old and new values.
+        $mapping = [
+            'before' => 'end',
+            'after' => 'start',
+        ];
+
+        // Get all localizations and make sure they exist.
+        $siteDefaults = Seo::find('site', 'general')
+            ?->ensureLocalizations(Site::all())
+            ->localizations();
+
+        // Get the title positions from each localization.
+        $titlePositions = $siteDefaults
+            ->map(fn ($data) => $data->get('title_position'))
+            ->filter()
+            ->map(fn ($value) => Arr::get($mapping, $value));
+
+        // Set the site name position for all collection defaults.
+        Seo::allOfType('collections')->each(function ($collection) use ($titlePositions) {
+            $titlePositions->each(function ($value, $site) use ($collection) {
+                $collection->in($site)
+                    ?->set('seo_site_name_position', $value)
+                    ->save();
+            });
+        });
+
+        // Set the site name position for all taxonomy defaults.
+        Seo::allOfType('taxonomies')->each(function ($taxonomy) use ($titlePositions) {
+            $titlePositions->each(function ($value, $site) use ($taxonomy) {
+                $taxonomy->in($site)
+                    ?->set('seo_site_name_position', $value)
+                    ->save();
+            });
+        });
+
+        // Set the site name position on entries.
+        Entry::query()
+            ->whereNull('origin') // Only set on default site.
+            ->whereNotNull('seo_title')
+            ->get()
+            ->each(fn ($entry) => $entry->set('seo_site_name_position', '@default')->saveQuietly());
+
+        // Set the site name position on terms.
+        Term::all()
+            ->filter(fn ($term) => $term->has('seo_title'))
+            ->each(fn ($term) => $term->set('seo_site_name_position', '@default')->save());
+
+        // Remove the old title position from the site defaults.
+        $siteDefaults
+            ->filter(fn ($default) => $default->has('title_position')) // Prevent saving of defaults with no title position
+            ->each(fn ($default) => $default->remove('title_position')->save());
+
+        $this->console()->info("Successfully migrated 'title_position' to 'site_name_position'.");
+    }
+}

--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -241,7 +241,7 @@ class Cascade
 
     protected function compiledTitle(): string
     {
-        $position = $this->value('site_name_position')->value();
+        $position = $this->value('site_name_position')?->value();
 
         return match (true) {
             ($position === 'end') => "{$this->title()} {$this->titleSeparator()} {$this->siteName()}",

--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -241,9 +241,14 @@ class Cascade
 
     protected function compiledTitle(): string
     {
-        return $this->value('title_position')->value() === 'before'
-            ? "{$this->title()} {$this->titleSeparator()} {$this->siteName()}"
-            : "{$this->siteName()} {$this->titleSeparator()} {$this->title()}";
+        $position = $this->value('site_name_position')->value();
+
+        return match (true) {
+            ($position === 'end') => "{$this->title()} {$this->titleSeparator()} {$this->siteName()}",
+            ($position === 'start') => "{$this->siteName()} {$this->titleSeparator()} {$this->title()}",
+            ($position === 'disabled') => $this->title(),
+            default => "{$this->title()} {$this->titleSeparator()} {$this->siteName()}",
+        };
     }
 
     protected function title(): string


### PR DESCRIPTION
This PR closes issue #22. It removes the `title_position` on the general site defaults in favor of a new `site_name_position` on the collection/taxonomy defaults and entry/term. This allows to control the way the site name is displayed for each entry/term. 

<img width="563" alt="Bildschirmfoto 2022-08-05 um 10 03 58" src="https://user-images.githubusercontent.com/23167701/183093495-78e5b576-2647-4a11-a34f-14f8202d998d.png">
 
This PR also includes a migration script that will automatically be run when updating to the latest version of Advanced SEO. So the user won't have to touch a thing on their end. It will just work.