### PR TITLE
Fix exception when executing actions

### DIFF
--- a/src/Actions/ShouldGenerateSocialImages.php
+++ b/src/Actions/ShouldGenerateSocialImages.php
@@ -3,14 +3,21 @@
 namespace Aerni\AdvancedSeo\Actions;
 
 use Aerni\AdvancedSeo\Facades\Seo;
+use Illuminate\Support\Str;
 use Statamic\Contracts\Entries\Entry;
+use Statamic\Statamic;
 
 class ShouldGenerateSocialImages
 {
     public static function handle(Entry $entry): bool
     {
         // Don't generate if we're first localiting an entry.
-        if (str_contains(request()->path(), 'localize')) {
+        if (Statamic::isCpRoute() && Str::contains(request()->path(), 'localize')) {
+            return false;
+        }
+
+        // Don't generate if the user is performing an action on the listing view.
+        if (Statamic::isCpRoute() && Str::contains(request()->path(), 'actions')) {
             return false;
         }
 


### PR DESCRIPTION
This PR fixes an exception that would occur when performing an action on the entry listing view on an entry that had the social images generator turned on.

The issue would happen because the blueprint of the entry is not extended. And so when it comes to generating the image, the generator couldn't determine which Twitter card to use when the value is set to `@default`.