### PR TITLE
Social images generator action

### DIFF
--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -26,7 +26,8 @@ return [
 
     'social_images_generator_save_sync' => 'Save the entry to generate the image.',
     'social_images_generator_save_queue' => 'Save the entry to generate the image in the background.',
-    'social_images_generator_generating_queue' => 'Generating the social images in the background',
+    'social_images_generator_generating_queue' => 'Generating the social images in the background.',
+    'social_images_generator_generated' => 'The social images have been successfully generated.',
     'social_images_generator_on_demand' => 'The image will be generated the first time you visit the URL of this entry.',
 
     'field_sources' => [

--- a/src/Actions/ShouldGenerateSocialImages.php
+++ b/src/Actions/ShouldGenerateSocialImages.php
@@ -2,7 +2,7 @@
 
 namespace Aerni\AdvancedSeo\Actions;
 
-use Aerni\AdvancedSeo\Facades\Seo;
+use Aerni\AdvancedSeo\Features\SocialImagesGenerator;
 use Illuminate\Support\Str;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Statamic;
@@ -11,38 +11,22 @@ class ShouldGenerateSocialImages
 {
     public static function handle(Entry $entry): bool
     {
-        // Don't generate if we're first localiting an entry.
+        // Don't generate if the social images generator feature is disabled.
+        if (! SocialImagesGenerator::enabled(GetDefaultsData::handle($entry))) {
+            return false;
+        }
+
+        // Don't generate if the entry is saved when first localizing an entry.
         if (Statamic::isCpRoute() && Str::contains(request()->path(), 'localize')) {
             return false;
         }
 
-        // Don't generate if the user is performing an action on the listing view.
+        // Don't generate if the entry is saved when an action is performed on the listing view.
         if (Statamic::isCpRoute() && Str::contains(request()->path(), 'actions')) {
             return false;
         }
 
-        // Shouldn't generate if the generator was disabled in the config.
-        if (! config('advanced-seo.social_images.generator.enabled', false)) {
-            return false;
-        }
-
-        $disabled = config('advanced-seo.disabled.collections', []);
-
-        // Check if the collection is set to be disabled globally.
-        if (in_array($entry->collectionHandle(), $disabled)) {
-            return false;
-        }
-
-        // Get the collections that are allowed to generate social images.
-        $enabledCollections = Seo::find('site', 'social_media')
-            ?->in($entry->site()->handle())
-            ?->value('social_images_generator_collections') ?? [];
-
-        // Shouldn't generate if the entry's collection is not selected.
-        if (! in_array($entry->collectionHandle(), $enabledCollections)) {
-            return false;
-        }
-
+        // Only generate if the social images generator is turned on.
         return $entry->seo_generate_social_images;
     }
 }

--- a/src/Actions/Statamic/GenerateSocialImages.php
+++ b/src/Actions/Statamic/GenerateSocialImages.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Aerni\AdvancedSeo\Actions\Statamic;
+
+use Aerni\AdvancedSeo\Actions\GetDefaultsData;
+use Aerni\AdvancedSeo\Features\SocialImagesGenerator;
+use Aerni\AdvancedSeo\Jobs\GenerateSocialImagesJob;
+use Statamic\Actions\Action;
+use Statamic\Contracts\Entries\Entry;
+
+class GenerateSocialImages extends Action
+{
+    /**
+     * Determine if the current thing is an entry and if it's opted in to the auto generation config (global).
+     *
+     * @return bool
+     */
+    public function visibleTo($item)
+    {
+        return $item instanceof Entry && SocialImagesGenerator::enabled(GetDefaultsData::handle($item));
+    }
+
+    /**
+     * Determine if the current user is allowed to run this action.
+     *
+     * @return bool
+     */
+    public function authorize($user, $item)
+    {
+        return $user->can('edit', $item);
+    }
+
+    /**
+     * Run the action
+     *
+     * @return void
+     */
+    public function run($items, $values)
+    {
+        $items->each(fn ($item) => GenerateSocialImagesJob::dispatch($item));
+
+        return config('queue.default') === 'sync'
+            ? __('advanced-seo::messages.social_images_generator_generated')
+            : __('advanced-seo::messages.social_images_generator_generating_queue');
+    }
+}

--- a/src/Commands/GenerateSocialImages.php
+++ b/src/Commands/GenerateSocialImages.php
@@ -2,7 +2,8 @@
 
 namespace Aerni\AdvancedSeo\Commands;
 
-use Aerni\AdvancedSeo\Actions\ShouldGenerateSocialImages;
+use Aerni\AdvancedSeo\Actions\GetDefaultsData;
+use Aerni\AdvancedSeo\Features\SocialImagesGenerator;
 use Aerni\AdvancedSeo\Jobs\GenerateSocialImagesJob;
 use Illuminate\Console\Command;
 use Statamic\Console\RunsInPlease;
@@ -17,24 +18,24 @@ class GenerateSocialImages extends Command
 
     public function handle(): void
     {
-        $entries = Entry::all()->filter(fn ($entry) => ShouldGenerateSocialImages::handle($entry));
+        $entries = Entry::all()->filter(fn ($entry) => SocialImagesGenerator::enabled(GetDefaultsData::handle($entry)));
 
         if ($entries->isEmpty()) {
-            $this->info("There are no images to generate");
+            $this->info('There are no images to generate');
 
             return;
         }
 
         if (config('queue.default') === 'sync') {
-            $this->info("Generating social images ...");
+            $this->info('Generating social images ...');
             $this->withProgressBar($entries, fn ($entry) => GenerateSocialImagesJob::dispatch($entry));
             $this->newLine();
-            $this->info("<info>[✓]</info> The social images have been succesfully generated");
+            $this->info('<info>[✓]</info> The social images have been succesfully generated');
 
             return;
         }
 
         $entries->each(fn ($entry) => GenerateSocialImagesJob::dispatch($entry));
-        $this->info("The social images are being generated in the background");
+        $this->info('The social images are being generated in the background');
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -38,6 +38,10 @@ use Statamic\Tags\Context;
 
 class ServiceProvider extends AddonServiceProvider
 {
+    protected $actions = [
+        Actions\Statamic\GenerateSocialImages::class,
+    ];
+
     protected $commands = [
         Commands\GenerateSocialImages::class,
         Commands\MakeTheme::class,

--- a/src/Subscribers/OnPageSeoBlueprintSubscriber.php
+++ b/src/Subscribers/OnPageSeoBlueprintSubscriber.php
@@ -143,8 +143,8 @@ class OnPageSeoBlueprintSubscriber
             return false;
         }
 
-        // Don't add fields for any requests other than the one of the current entry/term.
-        if (Statamic::isCpRoute() && ! $this->isCurrentCpRoute($event)) {
+        // Don't add fields to any other CP route other than the entry/term view and when performing an action on the listing view (necesarry for the social images generator action to work).
+        if (Statamic::isCpRoute() && ! $this->isModelCpRoute($event) && ! $this->isActionCpRoute()) {
             return false;
         }
 
@@ -156,7 +156,7 @@ class OnPageSeoBlueprintSubscriber
         return in_array($this->data->handle, config("advanced-seo.disabled.{$this->data->type}", []));
     }
 
-    protected function isCurrentCpRoute(Event $event): bool
+    protected function isModelCpRoute(Event $event): bool
     {
         // Has a value if editing or localizing an existing entry/term.
         $id = $this->data->type === 'collections' ? $event->entry?->id() : $event->term?->slug();
@@ -169,6 +169,11 @@ class OnPageSeoBlueprintSubscriber
          * But we only want to extend the blueprint for the current localization.
          * Otherwise we will have issue evaluating conditional fields, e.g. the sitemap fields.
          */
-        return Str::containsAll(request()->path(), [config('statamic.cp.route', 'cp'), $this->data->type, $id ?? $createLocale]);
+        return Statamic::isCpRoute() && Str::containsAll(request()->path(), [$this->data->type, $id ?? $createLocale]);
+    }
+
+    protected function isActionCpRoute(): bool
+    {
+        return Statamic::isCpRoute() && Str::containsAll(request()->path(), [$this->data->type, $this->data->handle, 'actions']);
     }
 }


### PR DESCRIPTION
This PR optimizes the social images generator in a few ways:

- Action: Adds action to generate social images from the entries listing
- Command: All social images for entries of enabled collections will now be generated. Not just the entries that have the generator toggle turned on.