### PR TITLE
Add support for variables

### DIFF
--- a/src/Fields/OnPageSeoFields.php
+++ b/src/Fields/OnPageSeoFields.php
@@ -47,10 +47,10 @@ class OnPageSeoFields extends BaseFields
                     'auto' => 'title',
                     'localizable' => true,
                     'classes' => 'text-fieldtype',
+                    'antlers' => true,
                     'field' => [
                         'type' => 'text',
                         'character_limit' => 60,
-                        'antlers' => false,
                     ],
                 ],
             ],
@@ -63,6 +63,7 @@ class OnPageSeoFields extends BaseFields
                     'default' => '@default',
                     'localizable' => true,
                     'classes' => 'textarea-fieldtype',
+                    'antlers' => true,
                     'field' => [
                         'type' => 'textarea',
                         'character_limit' => 160,
@@ -226,10 +227,10 @@ class OnPageSeoFields extends BaseFields
                     'auto' => 'seo_title',
                     'localizable' => true,
                     'classes' => 'text-fieldtype',
+                    'antlers' => true,
                     'field' => [
                         'type' => 'text',
                         'character_limit' => 70,
-                        'antlers' => false,
                     ],
                 ],
             ],
@@ -243,6 +244,7 @@ class OnPageSeoFields extends BaseFields
                     'auto' => 'seo_description',
                     'localizable' => true,
                     'classes' => 'textarea-fieldtype',
+                    'antlers' => true,
                     'field' => [
                         'type' => 'textarea',
                         'character_limit' => 200,
@@ -349,10 +351,10 @@ class OnPageSeoFields extends BaseFields
                     'auto' => 'seo_title',
                     'localizable' => true,
                     'classes' => 'text-fieldtype',
+                    'antlers' => true,
                     'field' => [
                         'type' => 'text',
                         'character_limit' => 70,
-                        'antlers' => false,
                     ],
                 ],
             ],
@@ -366,6 +368,7 @@ class OnPageSeoFields extends BaseFields
                     'auto' => 'seo_description',
                     'localizable' => true,
                     'classes' => 'textarea-fieldtype',
+                    'antlers' => true,
                     'field' => [
                         'type' => 'textarea',
                         'character_limit' => 200,
@@ -437,6 +440,7 @@ class OnPageSeoFields extends BaseFields
                     'default' => '@default',
                     'localizable' => true,
                     'classes' => 'text-fieldtype',
+                    'antlers' => true,
                     'if' => [
                         'seo_canonical_type.value' => 'equals custom',
                     ],
@@ -630,6 +634,7 @@ class OnPageSeoFields extends BaseFields
                     'default' => '@default',
                     'localizable' => true,
                     'classes' => 'code-fieldtype',
+                    'antlers' => true,
                     'field' => [
                         'type' => 'code',
                         'theme' => 'material',

--- a/src/Fieldtypes/ComputedValueFieldtype.php
+++ b/src/Fieldtypes/ComputedValueFieldtype.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Aerni\AdvancedSeo\Fieldtypes;
+
+use Statamic\Fields\Fieldtype;
+
+class ComputedValueFieldtype extends Fieldtype
+{
+    protected $selectable = false;
+
+    public function config(string $key = null, $fallback = null)
+    {
+        $config = collect([
+            'antlers' => true,
+        ]);
+
+        return $key
+            ? $config->get($key, $fallback)
+            : $config->all();
+    }
+}

--- a/src/Fieldtypes/SourceFieldtype.php
+++ b/src/Fieldtypes/SourceFieldtype.php
@@ -75,7 +75,11 @@ class SourceFieldtype extends Fieldtype
         $data = $data ?? $this->field->defaultValue();
 
         if ($data === '@default') {
-            return $this->sourceFieldtype()->augment($this->defaultValueFromCascade());
+            $value = $this->sourceFieldtype()->augment($this->defaultValueFromCascade());
+
+            return Str::contains($value, '@field:')
+                ? $this->parseFieldValues($value)
+                : $value;
         }
 
         if ($data === '@auto') {

--- a/src/Fieldtypes/SourceFieldtype.php
+++ b/src/Fieldtypes/SourceFieldtype.php
@@ -168,6 +168,9 @@ class SourceFieldtype extends Fieldtype
 
         $parent = $parent->toAugmentedArray();
 
+        // Prevent infinite loop by removing the field if it's part of the data.
+        $data = Str::of($data)->remove("@field:{$this->field->handle()}")->trim();
+
         preg_match_all('/@field:([A-z\d+-_]+)/', $data, $matches);
 
         $fieldValues = [];

--- a/src/Fieldtypes/SourceFieldtype.php
+++ b/src/Fieldtypes/SourceFieldtype.php
@@ -77,7 +77,7 @@ class SourceFieldtype extends Fieldtype
         if ($data === '@default') {
             $value = $this->sourceFieldtype()->augment($this->defaultValueFromCascade());
 
-            return Str::contains($value, '@field:')
+            return is_string($data) && Str::contains($value, '@field:')
                 ? $this->parseFieldValues($value)
                 : $value;
         }
@@ -86,7 +86,7 @@ class SourceFieldtype extends Fieldtype
             return $this->autoValue();
         }
 
-        if (Str::contains($data, '@field:')) {
+        if (is_string($data) && Str::contains($data, '@field:')) {
             return $this->parseFieldValues($data);
         }
 

--- a/src/Fieldtypes/SourceFieldtype.php
+++ b/src/Fieldtypes/SourceFieldtype.php
@@ -78,7 +78,7 @@ class SourceFieldtype extends Fieldtype
             $value = $this->sourceFieldtype()->augment($this->defaultValueFromCascade());
 
             return is_string($data) && Str::contains($value, '@field')
-                ? $this->parseFieldValues($value)
+                ? $this->sourceFieldtype()->augment($this->parseFieldValues($value))
                 : $value;
         }
 
@@ -87,7 +87,7 @@ class SourceFieldtype extends Fieldtype
         }
 
         if (is_string($data) && Str::contains($data, '@field')) {
-            return $this->parseFieldValues($data);
+            return $this->sourceFieldtype()->augment($this->parseFieldValues($data));
         }
 
         if ($data === '@null') {

--- a/src/Fieldtypes/SourceFieldtype.php
+++ b/src/Fieldtypes/SourceFieldtype.php
@@ -77,7 +77,7 @@ class SourceFieldtype extends Fieldtype
         if ($data === '@default') {
             $value = $this->sourceFieldtype()->augment($this->defaultValueFromCascade());
 
-            return is_string($data) && Str::contains($value, '@field:')
+            return is_string($data) && Str::contains($value, '@field')
                 ? $this->parseFieldValues($value)
                 : $value;
         }
@@ -86,7 +86,7 @@ class SourceFieldtype extends Fieldtype
             return $this->autoValue();
         }
 
-        if (is_string($data) && Str::contains($data, '@field:')) {
+        if (is_string($data) && Str::contains($data, '@field')) {
             return $this->parseFieldValues($data);
         }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -49,9 +49,10 @@ class ServiceProvider extends AddonServiceProvider
     ];
 
     protected $fieldtypes = [
+        Fieldtypes\AdvancedSeoFieldtype::class,
+        Fieldtypes\ComputedValueFieldtype::class,
         Fieldtypes\SocialImageFieldtype::class,
         Fieldtypes\SourceFieldtype::class,
-        Fieldtypes\AdvancedSeoFieldtype::class,
     ];
 
     // protected $listen = [

--- a/src/View/AugmentedCascade.php
+++ b/src/View/AugmentedCascade.php
@@ -2,7 +2,9 @@
 
 namespace Aerni\AdvancedSeo\View;
 
+use Aerni\AdvancedSeo\Fieldtypes\ComputedValueFieldtype;
 use Statamic\Data\AbstractAugmented;
+use Statamic\Fields\Value;
 
 class AugmentedCascade extends AbstractAugmented
 {
@@ -16,5 +18,20 @@ class AugmentedCascade extends AbstractAugmented
             ->merge($dataKeys)
             ->merge($computedKeys)
             ->unique()->sort()->values()->all();
+    }
+
+    protected function wrapValue($value, $handle)
+    {
+        $fields = $this->blueprintFields();
+
+        /**
+         * Add a dummy fieldtype for any field that doesn't have a fieldtype.
+         * This is needed so that we can parse Antlers in the view.
+         * Antlers can only be parsed if the Value object has a fieldtype.
+         */
+        $fieldtype = $fields->get($handle)?->fieldtype()
+            ?? new ComputedValueFieldtype();
+
+        return new Value($value, $handle, $fieldtype, $this->data);
     }
 }


### PR DESCRIPTION
This PR adds support for variables in any text, textarea, and code field.

## Basic Usage
Support for variables comes in two flavors.

**Antlers**
Our beloved Antlers. Use it like you're used to:

```yaml
seo_title: '{{ title }}'
```

**@field**
Unlike Antlers, this syntax also works with GraphQL:

```yaml
seo_title: '@field:title'
```

## Advanced Usage
You can also get values from linked entries:

```yaml
# Antlers
seo_title: '{{ event:title }}'

# @field
seo_title: '@field:event:title'
```

If you want to go totally nuts, this works too:

```yaml
# in an entry
seo_title: '@default'

# in the collection defaults
seo_title: '@field:title'
```
