### PR TITLE
Fix issue with requests that don't have a route

### DIFF
--- a/src/Support/Helpers.php
+++ b/src/Support/Helpers.php
@@ -34,7 +34,7 @@ class Helpers
             'Statamic\Http\Controllers\FrontendController@index',
         ]);
 
-        $controllerAction = request()->route()->getAction('controller');
+        $controllerAction = request()->route()?->getAction('controller');
 
         return $allowedControllerActions->doesntContain($controllerAction);
     }


### PR DESCRIPTION
Some request don’t have routes. I ran into this when sending an email. We might need a better way to check if a route is a custom route. But for now this should fix the issue.