### PR TITLE
Make sure to output fallback fathom domain

### DIFF
--- a/resources/views/snippets/_analytics.antlers.html
+++ b/resources/views/snippets/_analytics.antlers.html
@@ -3,7 +3,7 @@
     {{# Fathom #}}
     {{ if seo:use_fathom }}
         <script
-            src="https://{{ seo:fathom_domain ?? 'cdn.usefathom.com' }}/script.js"
+            src="https://{{ $seo:fathom_domain ?? 'cdn.usefathom.com' }}/script.js"
             data-site="{{ seo:fathom_id }}"
             defer
             {{ if seo:fathom_spa }}data-spa='auto'{{ /if }}


### PR DESCRIPTION
This PR fixes an issue where the fallback `cdn.usefathom.com` wouldn't be output when the `fathom_domain` wasn't defined. The fallback wasn't output because Antlers will interpret `seo:fathom_domain` as a tag if it doesn't exist as a variable. Luckily there is a simple fix. We can use [disambiguation](https://statamic.dev/antlers#disambiguating-variables) to explicitly tell the parser that we are looking for a variable.