### PR TITLE
Fix exception if value isn’t a string

### DIFF
--- a/src/Migrators/SeoProMigrator.php
+++ b/src/Migrators/SeoProMigrator.php
@@ -59,7 +59,8 @@ class SeoProMigrator extends BaseMigrator
 
         return $data
             ->merge($transformed)
-            ->map(fn ($value) => is_string($value) && Str::contains($value, '@seo:')
+            ->map(
+                fn ($value) => is_string($value) && Str::contains($value, '@seo:')
                 ? Str::replace('@seo:', '@field:', $value)
                 : $value
             );

--- a/src/Migrators/SeoProMigrator.php
+++ b/src/Migrators/SeoProMigrator.php
@@ -59,8 +59,7 @@ class SeoProMigrator extends BaseMigrator
 
         return $data
             ->merge($transformed)
-            ->map(
-                fn ($value) => Str::contains($value, '@seo:')
+            ->map(fn ($value) => is_string($value) && Str::contains($value, '@seo:')
                 ? Str::replace('@seo:', '@field:', $value)
                 : $value
             );


### PR DESCRIPTION
This PR fixes an exception with the SEO Pro Migrator that occurred when dealing with non-string values.