### PR TITLE
Fathom: remove support for custom domains

### DIFF
--- a/lang/en/fields.php
+++ b/lang/en/fields.php
@@ -220,11 +220,6 @@ return [
         'instructions' => 'Add your site ID.',
     ],
 
-    'fathom_domain' => [
-        'display' => 'Custom Domain',
-        'instructions' => 'Add an optional custom domain.',
-    ],
-
     'fathom_spa' => [
         'display' => 'SPA Mode',
         'instructions' => 'Activate if your site is a single page application.',

--- a/resources/views/snippets/_analytics.antlers.html
+++ b/resources/views/snippets/_analytics.antlers.html
@@ -3,7 +3,7 @@
     {{# Fathom #}}
     {{ if seo:use_fathom }}
         <script
-            src="https://{{ $seo:fathom_domain ?? 'cdn.usefathom.com' }}/script.js"
+            src="https://cdn.usefathom.com/script.js"
             data-site="{{ seo:fathom_id }}"
             defer
             {{ if seo:fathom_spa }}data-spa='auto'{{ /if }}

--- a/src/Fields/AnalyticsFields.php
+++ b/src/Fields/AnalyticsFields.php
@@ -59,22 +59,6 @@ class AnalyticsFields extends BaseFields
                 ],
             ],
             [
-                'handle' => 'fathom_domain',
-                'field' => [
-                    'type' => 'text',
-                    'display' => $this->trans('fathom_domain.display'),
-                    'instructions' => $this->trans('fathom_domain.instructions'),
-                    'input_type' => 'text',
-                    'width' => 50,
-                    'listable' => 'hidden',
-                    'antlers' => true,
-                    'feature' => Fathom::class,
-                    'if' => [
-                        'use_fathom' => 'equals true',
-                    ],
-                ],
-            ],
-            [
                 'handle' => 'fathom_spa',
                 'field' => [
                     'type' => 'toggle',
@@ -82,6 +66,7 @@ class AnalyticsFields extends BaseFields
                     'instructions' => $this->trans('fathom_spa.instructions'),
                     'icon' => 'toggle',
                     'listable' => 'hidden',
+                    'width' => 50,
                     'feature' => Fathom::class,
                     'validate' => [
                         'required_if:use_fathom,true',


### PR DESCRIPTION
Fathom has removed support for customs domains as of May 9, 2023. See here: https://usefathom.com/docs/script/custom-domains