### PR TITLE
Betterify the output of the `RenderedViewsType`

### DIFF
--- a/resources/views/snippets/_knowledge_graph.antlers.html
+++ b/resources/views/snippets/_knowledge_graph.antlers.html
@@ -1,5 +1,14 @@
-{{# Outputs the site and entry JSON-LD Schema #}}
-{{ seo:schema }}
+{{# Outputs the site JSON-LD Schema #}}
+{{ if seo:site_schema }}
+    <script type="application/ld+json">{{ seo:site_schema }}</script>
+{{ /if }}
+
+{{# Outputs the page JSON-LD Schema #}}
+{{ if seo:page_schema }}
+    <script type="application/ld+json">{{ seo:page_schema }}</script>
+{{ /if }}
 
 {{# Outputs the breadcrumbs #}}
-{{ seo:breadcrumbs }}
+{{ if seo:breadcrumbs }}
+    <script type="application/ld+json">{{ seo:breadcrumbs }}</script>
+{{ /if }}

--- a/src/GraphQL/Types/RenderedViewsType.php
+++ b/src/GraphQL/Types/RenderedViewsType.php
@@ -2,10 +2,10 @@
 
 namespace Aerni\AdvancedSeo\GraphQL\Types;
 
-use Statamic\Facades\GraphQL;
-use Rebing\GraphQL\Support\Type;
-use Illuminate\Contracts\View\View;
 use Aerni\AdvancedSeo\View\GraphQlCascade;
+use Illuminate\Contracts\View\View;
+use Rebing\GraphQL\Support\Type;
+use Statamic\Facades\GraphQL;
 
 class RenderedViewsType extends Type
 {

--- a/src/GraphQL/Types/RenderedViewsType.php
+++ b/src/GraphQL/Types/RenderedViewsType.php
@@ -2,9 +2,10 @@
 
 namespace Aerni\AdvancedSeo\GraphQL\Types;
 
-use Aerni\AdvancedSeo\View\GraphQlCascade;
-use Rebing\GraphQL\Support\Type;
 use Statamic\Facades\GraphQL;
+use Rebing\GraphQL\Support\Type;
+use Illuminate\Contracts\View\View;
+use Aerni\AdvancedSeo\View\GraphQlCascade;
 
 class RenderedViewsType extends Type
 {
@@ -20,12 +21,17 @@ class RenderedViewsType extends Type
         return [
             'head' => [
                 'type' => GraphQL::string(),
-                'resolve' => fn (GraphQlCascade $cascade) => view('advanced-seo::head', ['seo' => $cascade->toAugmentedArray()]),
+                'resolve' => fn (GraphQlCascade $cascade) => $this->formatView(view('advanced-seo::head', ['seo' => $cascade->toAugmentedArray()])),
             ],
             'body' => [
                 'type' => GraphQL::string(),
-                'resolve' => fn (GraphQlCascade $cascade) => view('advanced-seo::body', ['seo' => $cascade->toAugmentedArray()]),
+                'resolve' => fn (GraphQlCascade $cascade) => $this->formatView(view('advanced-seo::body', ['seo' => $cascade->toAugmentedArray()])),
             ],
         ];
+    }
+
+    protected function formatView(View $view): string
+    {
+        return preg_replace('/\s+/', ' ', $view->render());
     }
 }

--- a/src/View/GraphQlCascade.php
+++ b/src/View/GraphQlCascade.php
@@ -172,7 +172,7 @@ class GraphQlCascade extends BaseCascade
         return $hreflang;
     }
 
-    public function canonical(): string
+    public function canonical(): ?string
     {
         $type = $this->get('canonical_type');
 
@@ -276,7 +276,7 @@ class GraphQlCascade extends BaseCascade
         return $this;
     }
 
-    protected function buildUrl(mixed $model): string
+    protected function buildUrl(mixed $model): ?string
     {
         return $this->baseUrl
             ? URL::assemble($this->baseUrl, $model->url())

--- a/src/View/ViewCascade.php
+++ b/src/View/ViewCascade.php
@@ -57,7 +57,8 @@ class ViewCascade extends BaseCascade
             'canonical',
             'prev_url',
             'next_url',
-            'schema',
+            'site_schema',
+            'page_schema',
             'breadcrumbs',
         ]);
     }
@@ -311,14 +312,7 @@ class ViewCascade extends BaseCascade
             : null;
     }
 
-    public function schema(): ?string
-    {
-        $schema = $this->siteSchema().$this->entrySchema();
-
-        return ! empty($schema) ? $schema : null;
-    }
-
-    protected function siteSchema(): ?string
+    public function siteSchema(): ?string
     {
         $type = $this->get('site_json_ld_type');
 
@@ -327,11 +321,7 @@ class ViewCascade extends BaseCascade
         }
 
         if ($type == 'custom') {
-            $data = $this->get('site_json_ld');
-
-            return $data
-                ? '<script type="application/ld+json">'.$data.'</script>'
-                : null;
+            return $this->get('site_json_ld');
         }
 
         $siteUrl = $this->model->get('site')?->absoluteUrl() ?? Site::current()->absoluteUrl();
@@ -357,16 +347,12 @@ class ViewCascade extends BaseCascade
                 ->url($siteUrl);
         }
 
-        return $schema->toScript();
+        return json_encode($schema->toArray(), JSON_UNESCAPED_UNICODE);
     }
 
-    protected function entrySchema(): ?string
+    public function pageSchema(): ?string
     {
-        $data = $this->get('json_ld')?->value();
-
-        return $data
-            ? '<script type="application/ld+json">'.$data.'</script>'
-            : null;
+        return $this->get('json_ld')?->value();
     }
 
     public function breadcrumbs(): ?string
@@ -388,7 +374,9 @@ class ViewCascade extends BaseCascade
                 ->item($crumb['url']);
         })->all();
 
-        return Schema::breadcrumbList()->itemListElement($listItems);
+        $breadcrumbs = Schema::breadcrumbList()->itemListElement($listItems);
+
+        return json_encode($breadcrumbs->toArray(), JSON_UNESCAPED_UNICODE);
     }
 
     protected function breadcrumbsListItems(): Collection


### PR DESCRIPTION
This PR fixes issue #69 by moving the script tag from the `ViewCascade` into the `_knowledge_graph.antlers.html` view. This way, the rendered views returned by GraphQL will also include the script tag. This PR also strips any unnecessary `\n`.