### PR TITLE
updated base sitemap to allow alternate base URL

### DIFF
--- a/src/Sitemap/BaseSitemap.php
+++ b/src/Sitemap/BaseSitemap.php
@@ -34,7 +34,7 @@ abstract class BaseSitemap implements Sitemap
 
     public function url(): string
     {
-        $baseUrl = url('/');
+        $baseUrl = config('app.url');
         $filename = "sitemap-{$this->type()}-{$this->handle()}.xml";
 
         return URL::tidy("{$baseUrl}/{$filename}");


### PR DESCRIPTION
Added ability to configure the base URL for the index sitemap. This comes in handy when proxying to the sitemap from a headless frontend. 