### PR TITLE
Normalize path in getItemFilter

### DIFF
--- a/src/Stache/SeoDefaultsStore.php
+++ b/src/Stache/SeoDefaultsStore.php
@@ -6,19 +6,21 @@ use Aerni\AdvancedSeo\Data\SeoDefaultSet;
 use Aerni\AdvancedSeo\Data\SeoVariables;
 use Aerni\AdvancedSeo\Facades\Seo;
 use Statamic\Facades\File;
+use Statamic\Facades\Path;
 use Statamic\Facades\Site;
 use Statamic\Facades\YAML;
 use Statamic\Stache\Stores\ChildStore;
 use Statamic\Support\Arr;
 use Symfony\Component\Finder\SplFileInfo;
-use Statamic\Facades\Path;
 
 class SeoDefaultsStore extends ChildStore
 {
     public function getItemFilter(SplFileInfo $file): bool
     {
+        $filename = Path::tidy($file->getRelativePathname());
+
         // Only get the SeoDefaultSet that exists in the root. Don't get the SeoVariables.
-        return substr_count(Path::tidy($file->getRelativePathname()), '/') === 0
+        return substr_count($filename, '/') === 0
             && $file->getExtension() === 'yaml';
     }
 

--- a/src/Stache/SeoDefaultsStore.php
+++ b/src/Stache/SeoDefaultsStore.php
@@ -11,13 +11,14 @@ use Statamic\Facades\YAML;
 use Statamic\Stache\Stores\ChildStore;
 use Statamic\Support\Arr;
 use Symfony\Component\Finder\SplFileInfo;
+use Statamic\Facades\Path;
 
 class SeoDefaultsStore extends ChildStore
 {
     public function getItemFilter(SplFileInfo $file): bool
     {
         // Only get the SeoDefaultSet that exists in the root. Don't get the SeoVariables.
-        return substr_count($file->getRelativePathname(), '/') === 0
+        return substr_count(Path::tidy($file->getRelativePathname()), '/') === 0
             && $file->getExtension() === 'yaml';
     }
 


### PR DESCRIPTION
In Windows, the file paths have backslashes, which means getItemFilter returned the files that are localizations in the addition to the main file, if you have multi site enabled. This causes them to be marked as duplicates and other problems.

I don't know how I would go about adding a test for this, I would appreciate if you could add one @aerni 

I also haven't checked if this happens anywhere else. Most places seem to use Laravel paths which are normalized in contrast to this Symfony file object.

Fixes #60 