### PR TITLE
Only output taxonomy and term sitemap URL's once

### DIFF
--- a/src/Sitemap/TaxonomySitemap.php
+++ b/src/Sitemap/TaxonomySitemap.php
@@ -88,7 +88,7 @@ class TaxonomySitemap extends BaseSitemap
             return collect();
         }
 
-        return $terms->flatMap(fn ($term) => $term->term()->localizations()->values()) // Get all localizations of the term.
+        return $terms
             ->filter(fn ($term) => $term->taxonomy()->sites()->contains($term->locale())) // We only want terms of sites that are configured on the taxonomy.
             ->filter(fn ($term) => Indexable::handle($term)); // We only want indexable terms.
     }


### PR DESCRIPTION
This PR fixes an issue that would cause taxonomy and term sitemap URL's to be output twice in a multi-site setup.