### PR TITLE
Add GraphQL support for sitemaps

### DIFF
--- a/src/Concerns/HasBaseUrl.php
+++ b/src/Concerns/HasBaseUrl.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Aerni\AdvancedSeo\Concerns;
+
+use Statamic\Support\Traits\FluentlyGetsAndSets;
+
+trait HasBaseUrl
+{
+    use FluentlyGetsAndSets;
+
+    protected ?string $baseUrl = null;
+
+    public function baseUrl(?string $baseUrl = null): self|string|null
+    {
+        return $this->fluentlyGetOrSet('baseUrl')->args(func_get_args());
+    }
+}

--- a/src/Concerns/HasBaseUrl.php
+++ b/src/Concerns/HasBaseUrl.php
@@ -10,7 +10,7 @@ trait HasBaseUrl
 
     protected ?string $baseUrl = null;
 
-    public function baseUrl(?string $baseUrl = null): self|string|null
+    public function baseUrl(string $baseUrl = null): self|string|null
     {
         return $this->fluentlyGetOrSet('baseUrl')->args(func_get_args());
     }

--- a/src/Contracts/SitemapUrl.php
+++ b/src/Contracts/SitemapUrl.php
@@ -14,6 +14,8 @@ interface SitemapUrl
 
     public function priority(): string|self|null;
 
+    public function site(): string|self;
+
     public function isCanonicalUrl(): bool;
 
     public function toArray(): ?array;

--- a/src/Data/SeoVariables.php
+++ b/src/Data/SeoVariables.php
@@ -18,14 +18,14 @@ use Statamic\GraphQL\ResolvesValues;
 use Statamic\Support\Arr;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
-class SeoVariables implements Localization, Augmentable
+class SeoVariables implements Augmentable, Localization
 {
     use ContainsData;
     use ExistsAsFile;
     use FluentlyGetsAndSets;
     use HasAugmentedInstance;
-    use HasOrigin;
     use HasDefaultsData;
+    use HasOrigin;
     use ResolvesValues {
         resolveGqlValue as traitResolveGqlValue;
     }

--- a/src/GraphQL/Queries/SeoSitemapQuery.php
+++ b/src/GraphQL/Queries/SeoSitemapQuery.php
@@ -15,6 +15,15 @@ class SeoSitemapQuery extends Query
         'description' => 'The Advanced SEO sitemap',
     ];
 
+    public function args(): array
+    {
+        return [
+            'site' => [
+                'type' => GraphQL::string(),
+            ],
+        ];
+    }
+
     public function type(): Type
     {
         return GraphQL::listOf(GraphQL::type(SeoSitemapType::NAME));
@@ -22,9 +31,12 @@ class SeoSitemapQuery extends Query
 
     public function resolve($root, $args)
     {
-        // TODO: Don't return anything if sitemaps are disabled?
-        // throw_unless(config('advanced-seo.sitemap.enabled'), new NotFoundHttpException);
+        $sitemapUrls = Sitemap::all()->flatMap->urls();
 
-        return Sitemap::all()->flatMap->urls();
+        if ($site = $args['site'] ?? null) {
+            $sitemapUrls = $sitemapUrls->where('site', $site);
+        }
+
+        return $sitemapUrls;
     }
 }

--- a/src/GraphQL/Queries/SeoSitemapQuery.php
+++ b/src/GraphQL/Queries/SeoSitemapQuery.php
@@ -18,6 +18,12 @@ class SeoSitemapQuery extends Query
     public function args(): array
     {
         return [
+            'handle' => [
+                'type' => GraphQL::string(),
+            ],
+            'type' => [
+                'type' => GraphQL::string(),
+            ],
             'site' => [
                 'type' => GraphQL::string(),
             ],
@@ -31,12 +37,22 @@ class SeoSitemapQuery extends Query
 
     public function resolve($root, $args)
     {
-        $sitemapUrls = Sitemap::all()->flatMap->urls();
+        $sitemaps = Sitemap::all();
+
+        if ($handle = $args['handle'] ?? null) {
+            $sitemaps = $sitemaps->filter(fn ($sitemap) => $sitemap->handle() === $handle);
+        }
+
+        if ($type = $args['type'] ?? null) {
+            $sitemaps = $sitemaps->filter(fn ($sitemap) => $sitemap->type() === $type);
+        }
+
+        $sitemapUrls = $sitemaps->flatMap->urls();
 
         if ($site = $args['site'] ?? null) {
             $sitemapUrls = $sitemapUrls->where('site', $site);
         }
 
-        return $sitemapUrls;
+        return $sitemapUrls->isNotEmpty() ? $sitemapUrls : null;
     }
 }

--- a/src/GraphQL/Queries/SeoSitemapQuery.php
+++ b/src/GraphQL/Queries/SeoSitemapQuery.php
@@ -20,15 +20,22 @@ class SeoSitemapQuery extends Query
         return [
             'baseUrl' => [
                 'type' => GraphQL::string(),
+                'description' => 'Change the base URL if your frontend is hosted on another domain than Statamic',
+                'rules' => ['url'],
             ],
             'handle' => [
                 'type' => GraphQL::string(),
+                'description' => 'Filter the results by the handle of a collection, taxonomy, or custom sitemap',
             ],
             'type' => [
                 'type' => GraphQL::string(),
+                'description' => 'Filter the results by type. Either `collection`, `taxonomy`, or `custom`.',
+                'rules' => ['in:collection,taxonomy,custom'],
             ],
             'site' => [
                 'type' => GraphQL::string(),
+                'description' => 'Filter the results by site',
+                'rules' => ['in:collection,taxonomy,custom'],
             ],
         ];
     }

--- a/src/GraphQL/Queries/SeoSitemapQuery.php
+++ b/src/GraphQL/Queries/SeoSitemapQuery.php
@@ -18,6 +18,9 @@ class SeoSitemapQuery extends Query
     public function args(): array
     {
         return [
+            'baseUrl' => [
+                'type' => GraphQL::string(),
+            ],
             'handle' => [
                 'type' => GraphQL::string(),
             ],
@@ -37,7 +40,8 @@ class SeoSitemapQuery extends Query
 
     public function resolve($root, $args)
     {
-        $sitemaps = Sitemap::all();
+        $sitemaps = Sitemap::all()
+            ->each(fn ($sitemap) => $sitemap->baseUrl($args['baseUrl'] ?? null));
 
         if ($handle = $args['handle'] ?? null) {
             $sitemaps = $sitemaps->filter(fn ($sitemap) => $sitemap->handle() === $handle);

--- a/src/GraphQL/Queries/SeoSitemapQuery.php
+++ b/src/GraphQL/Queries/SeoSitemapQuery.php
@@ -44,11 +44,11 @@ class SeoSitemapQuery extends Query
             ->each(fn ($sitemap) => $sitemap->baseUrl($args['baseUrl'] ?? null));
 
         if ($handle = $args['handle'] ?? null) {
-            $sitemaps = $sitemaps->filter(fn ($sitemap) => $sitemap->handle() === $handle);
+            $sitemaps = $sitemaps->filter(fn ($sitemap) => $handle === $sitemap->handle());
         }
 
         if ($type = $args['type'] ?? null) {
-            $sitemaps = $sitemaps->filter(fn ($sitemap) => $sitemap->type() === $type);
+            $sitemaps = $sitemaps->filter(fn ($sitemap) => $type === $sitemap->type());
         }
 
         $sitemapUrls = $sitemaps->flatMap->urls();

--- a/src/GraphQL/Queries/SeoSitemapQuery.php
+++ b/src/GraphQL/Queries/SeoSitemapQuery.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Aerni\AdvancedSeo\GraphQL\Queries;
+
+use Aerni\AdvancedSeo\Facades\Sitemap;
+use Aerni\AdvancedSeo\GraphQL\Types\SeoSitemapType;
+use GraphQL\Type\Definition\Type;
+use Statamic\Facades\GraphQL;
+use Statamic\GraphQL\Queries\Query;
+
+class SeoSitemapQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'seoSitemap',
+        'description' => 'The Advanced SEO sitemap',
+    ];
+
+    public function type(): Type
+    {
+        return GraphQL::listOf(GraphQL::type(SeoSitemapType::NAME));
+    }
+
+    public function resolve($root, $args)
+    {
+        // TODO: Don't return anything if sitemaps are disabled?
+        // throw_unless(config('advanced-seo.sitemap.enabled'), new NotFoundHttpException);
+
+        return Sitemap::all()->flatMap->urls();
+    }
+}

--- a/src/GraphQL/Queries/SeoSitemapsQuery.php
+++ b/src/GraphQL/Queries/SeoSitemapsQuery.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Aerni\AdvancedSeo\GraphQL\Queries;
+
+use Aerni\AdvancedSeo\GraphQL\Types\SeoSitemapsType;
+use GraphQL\Type\Definition\Type;
+use Statamic\Facades\GraphQL;
+use Statamic\GraphQL\Queries\Query;
+
+class SeoSitemapsQuery extends Query
+{
+    protected $attributes = [
+        'name' => 'seoSitemaps',
+        'description' => 'The Advanced SEO sitemaps',
+    ];
+
+    public function type(): Type
+    {
+        return GraphQL::type(SeoSitemapsType::NAME);
+    }
+
+    public function resolve($root, $args)
+    {
+        return $args;
+    }
+}

--- a/src/GraphQL/Types/SeoSitemapType.php
+++ b/src/GraphQL/Types/SeoSitemapType.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Aerni\AdvancedSeo\GraphQL\Types;
+
+use Rebing\GraphQL\Support\Type;
+use Statamic\Facades\GraphQL;
+
+class SeoSitemapType extends Type
+{
+    const NAME = 'seoSitemap';
+
+    protected $attributes = [
+        'name' => self::NAME,
+        'description' => 'The Advanced SEO sitemap',
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'alternates' => [
+                'type' => GraphQL::listOf(GraphQL::type(SitemapAlternatesType::NAME)),
+                'description' => 'The Advanced SEO sitemap alternates',
+                'resolve' => fn (array $sitemap) => $sitemap['alternates'], // TODO: Return null if empty. Should do this in the CollectionSitemapUrl class.
+            ],
+            'changefreq' => [
+                'type' => GraphQL::string(),
+                'description' => 'The Advanced SEO sitemap changefreq',
+                'resolve' => fn (array $sitemap) => $sitemap['changefreq'],
+            ],
+            'lastmod' => [
+                'type' => GraphQL::string(),
+                'description' => 'The Advanced SEO sitemap lastmod',
+                'resolve' => fn (array $sitemap) => $sitemap['lastmod'],
+            ],
+            'loc' => [
+                'type' => GraphQL::string(),
+                'description' => 'The Advanced SEO sitemap loc',
+                'resolve' => fn (array $sitemap) => $sitemap['loc'],
+            ],
+            'priority' => [
+                'type' => GraphQL::string(),
+                'description' => 'The Advanced SEO sitemap priority',
+                'resolve' => fn (array $sitemap) => $sitemap['priority'],
+            ],
+        ];
+    }
+}

--- a/src/GraphQL/Types/SeoSitemapType.php
+++ b/src/GraphQL/Types/SeoSitemapType.php
@@ -20,7 +20,7 @@ class SeoSitemapType extends Type
             'alternates' => [
                 'type' => GraphQL::listOf(GraphQL::type(SitemapAlternatesType::NAME)),
                 'description' => 'The Advanced SEO sitemap alternates',
-                'resolve' => fn (array $sitemap) => $sitemap['alternates'], // TODO: Return null if empty. Should do this in the CollectionSitemapUrl class.
+                'resolve' => fn (array $sitemap) => $sitemap['alternates'],
             ],
             'changefreq' => [
                 'type' => GraphQL::string(),

--- a/src/GraphQL/Types/SeoSitemapsType.php
+++ b/src/GraphQL/Types/SeoSitemapsType.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Aerni\AdvancedSeo\GraphQL\Types;
+
+use Aerni\AdvancedSeo\GraphQL\Fields\SitemapField;
+use Rebing\GraphQL\Support\Type;
+
+class SeoSitemapsType extends Type
+{
+    const NAME = 'seoSitemaps';
+
+    protected $attributes = [
+        'name' => self::NAME,
+        'description' => 'The Advanced SEO sitemaps',
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'collection' => new SitemapField,
+            'taxonomy' => new SitemapField,
+            'custom' => new SitemapField,
+        ];
+    }
+}

--- a/src/GraphQL/Types/SitemapAlternatesType.php
+++ b/src/GraphQL/Types/SitemapAlternatesType.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Aerni\AdvancedSeo\GraphQL\Types;
+
+use Rebing\GraphQL\Support\Type;
+use Statamic\Facades\GraphQL;
+
+class SitemapAlternatesType extends Type
+{
+    const NAME = 'sitemapAlternates';
+
+    protected $attributes = [
+        'name' => self::NAME,
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'href' => [
+                'type' => GraphQl::string(),
+                'resolve' => fn (array $alternate) => $alternate['href'],
+            ],
+            'hreflang' => [
+                'type' => GraphQl::string(),
+                'resolve' => fn (array $alternate) => $alternate['hreflang'],
+            ],
+        ];
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -7,7 +7,7 @@ use Aerni\AdvancedSeo\Data\SeoVariables;
 use Aerni\AdvancedSeo\GraphQL\Fields\SeoField;
 use Aerni\AdvancedSeo\GraphQL\Queries\SeoDefaultsQuery;
 use Aerni\AdvancedSeo\GraphQL\Queries\SeoMetaQuery;
-use Aerni\AdvancedSeo\GraphQL\Queries\SeoSitemapQuery;
+use Aerni\AdvancedSeo\GraphQL\Queries\SeoSitemapsQuery;
 use Aerni\AdvancedSeo\GraphQL\Types\AnalyticsDefaultsType;
 use Aerni\AdvancedSeo\GraphQL\Types\ComputedMetaDataType;
 use Aerni\AdvancedSeo\GraphQL\Types\ContentDefaultsType;
@@ -19,6 +19,7 @@ use Aerni\AdvancedSeo\GraphQL\Types\RawMetaDataType;
 use Aerni\AdvancedSeo\GraphQL\Types\RenderedViewsType;
 use Aerni\AdvancedSeo\GraphQL\Types\SeoDefaultsType;
 use Aerni\AdvancedSeo\GraphQL\Types\SeoMetaType;
+use Aerni\AdvancedSeo\GraphQL\Types\SeoSitemapsType;
 use Aerni\AdvancedSeo\GraphQL\Types\SeoSitemapType;
 use Aerni\AdvancedSeo\GraphQL\Types\SiteDefaultsType;
 use Aerni\AdvancedSeo\GraphQL\Types\SitemapAlternatesType;
@@ -209,7 +210,7 @@ class ServiceProvider extends AddonServiceProvider
         if (config('statamic.graphql.enabled') && config('advanced-seo.graphql')) {
             GraphQL::addQuery(SeoMetaQuery::class);
             GraphQL::addQuery(SeoDefaultsQuery::class);
-            GraphQL::addQuery(SeoSitemapQuery::class);
+            GraphQL::addQuery(SeoSitemapsQuery::class);
 
             GraphQL::addType(AnalyticsDefaultsType::class);
             GraphQL::addType(ComputedMetaDataType::class);
@@ -221,8 +222,10 @@ class ServiceProvider extends AddonServiceProvider
             GraphQL::addType(RawMetaDataType::class);
             GraphQL::addType(RenderedViewsType::class);
             GraphQL::addType(SeoDefaultsType::class);
-            GraphQL::addType(SeoMetaType::class);
+            GraphQL::addType(SeoSitemapsType::class);
             GraphQL::addType(SeoSitemapType::class);
+            GraphQL::addType(SeoDefaultsType::class);
+            GraphQL::addType(SeoMetaType::class);
             GraphQL::addType(SiteDefaultsType::class);
             GraphQL::addType(SitemapAlternatesType::class);
             GraphQL::addType(SocialImagePresetType::class);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -208,8 +208,8 @@ class ServiceProvider extends AddonServiceProvider
     protected function bootGraphQL(): self
     {
         if (config('statamic.graphql.enabled') && config('advanced-seo.graphql')) {
-            GraphQL::addQuery(SeoMetaQuery::class);
             GraphQL::addQuery(SeoDefaultsQuery::class);
+            GraphQL::addQuery(SeoMetaQuery::class);
             GraphQL::addQuery(SeoSitemapsQuery::class);
 
             GraphQL::addType(AnalyticsDefaultsType::class);
@@ -222,10 +222,9 @@ class ServiceProvider extends AddonServiceProvider
             GraphQL::addType(RawMetaDataType::class);
             GraphQL::addType(RenderedViewsType::class);
             GraphQL::addType(SeoDefaultsType::class);
+            GraphQL::addType(SeoMetaType::class);
             GraphQL::addType(SeoSitemapsType::class);
             GraphQL::addType(SeoSitemapType::class);
-            GraphQL::addType(SeoDefaultsType::class);
-            GraphQL::addType(SeoMetaType::class);
             GraphQL::addType(SiteDefaultsType::class);
             GraphQL::addType(SitemapAlternatesType::class);
             GraphQL::addType(SocialImagePresetType::class);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -7,6 +7,7 @@ use Aerni\AdvancedSeo\Data\SeoVariables;
 use Aerni\AdvancedSeo\GraphQL\Fields\SeoField;
 use Aerni\AdvancedSeo\GraphQL\Queries\SeoDefaultsQuery;
 use Aerni\AdvancedSeo\GraphQL\Queries\SeoMetaQuery;
+use Aerni\AdvancedSeo\GraphQL\Queries\SeoSitemapQuery;
 use Aerni\AdvancedSeo\GraphQL\Types\AnalyticsDefaultsType;
 use Aerni\AdvancedSeo\GraphQL\Types\ComputedMetaDataType;
 use Aerni\AdvancedSeo\GraphQL\Types\ContentDefaultsType;
@@ -18,7 +19,9 @@ use Aerni\AdvancedSeo\GraphQL\Types\RawMetaDataType;
 use Aerni\AdvancedSeo\GraphQL\Types\RenderedViewsType;
 use Aerni\AdvancedSeo\GraphQL\Types\SeoDefaultsType;
 use Aerni\AdvancedSeo\GraphQL\Types\SeoMetaType;
+use Aerni\AdvancedSeo\GraphQL\Types\SeoSitemapType;
 use Aerni\AdvancedSeo\GraphQL\Types\SiteDefaultsType;
+use Aerni\AdvancedSeo\GraphQL\Types\SitemapAlternatesType;
 use Aerni\AdvancedSeo\GraphQL\Types\SocialImagePresetType;
 use Aerni\AdvancedSeo\GraphQL\Types\SocialMediaDefaultsType;
 use Aerni\AdvancedSeo\Models\Defaults;
@@ -206,6 +209,7 @@ class ServiceProvider extends AddonServiceProvider
         if (config('statamic.graphql.enabled') && config('advanced-seo.graphql')) {
             GraphQL::addQuery(SeoMetaQuery::class);
             GraphQL::addQuery(SeoDefaultsQuery::class);
+            GraphQL::addQuery(SeoSitemapQuery::class);
 
             GraphQL::addType(AnalyticsDefaultsType::class);
             GraphQL::addType(ComputedMetaDataType::class);
@@ -216,10 +220,11 @@ class ServiceProvider extends AddonServiceProvider
             GraphQL::addType(IndexingDefaultsType::class);
             GraphQL::addType(RawMetaDataType::class);
             GraphQL::addType(RenderedViewsType::class);
-            GraphQL::addType(ContentDefaultsType::class);
-            GraphQL::addType(SeoMetaType::class);
             GraphQL::addType(SeoDefaultsType::class);
+            GraphQL::addType(SeoMetaType::class);
+            GraphQL::addType(SeoSitemapType::class);
             GraphQL::addType(SiteDefaultsType::class);
+            GraphQL::addType(SitemapAlternatesType::class);
             GraphQL::addType(SocialImagePresetType::class);
             GraphQL::addType(SocialMediaDefaultsType::class);
 

--- a/src/Sitemap/BaseSitemap.php
+++ b/src/Sitemap/BaseSitemap.php
@@ -2,6 +2,7 @@
 
 namespace Aerni\AdvancedSeo\Sitemap;
 
+use Aerni\AdvancedSeo\Concerns\HasBaseUrl;
 use Aerni\AdvancedSeo\Contracts\Sitemap;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
@@ -11,7 +12,7 @@ use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 abstract class BaseSitemap implements Sitemap
 {
-    use FluentlyGetsAndSets;
+    use FluentlyGetsAndSets, HasBaseUrl;
 
     abstract public function urls(): Collection;
 

--- a/src/Sitemap/BaseSitemapUrl.php
+++ b/src/Sitemap/BaseSitemapUrl.php
@@ -3,6 +3,11 @@
 namespace Aerni\AdvancedSeo\Sitemap;
 
 use Aerni\AdvancedSeo\Contracts\SitemapUrl;
+use Statamic\Contracts\Entries\Entry;
+use Statamic\Contracts\Taxonomies\Taxonomy;
+use Statamic\Contracts\Taxonomies\Term;
+use Statamic\Facades\URL;
+use Statamic\Sites\Site;
 
 abstract class BaseSitemapUrl implements SitemapUrl
 {
@@ -42,5 +47,12 @@ abstract class BaseSitemapUrl implements SitemapUrl
             'priority' => $this->priority(),
             'site' => $this->site(),
         ];
+    }
+
+    protected function absoluteUrl(Entry|Taxonomy|Term|Site $model): string
+    {
+        return $this->sitemap->baseUrl()
+            ? URL::assemble($this->sitemap->baseUrl(), $model->url())
+            : $model->absoluteUrl();
     }
 }

--- a/src/Sitemap/BaseSitemapUrl.php
+++ b/src/Sitemap/BaseSitemapUrl.php
@@ -16,6 +16,8 @@ abstract class BaseSitemapUrl implements SitemapUrl
 
     abstract public function priority(): string|self|null;
 
+    abstract public function site(): string|self;
+
     public function isCanonicalUrl(): bool
     {
         return true;
@@ -38,6 +40,7 @@ abstract class BaseSitemapUrl implements SitemapUrl
             'lastmod' => $this->lastmod(),
             'changefreq' => $this->changefreq(),
             'priority' => $this->priority(),
+            'site' => $this->site(),
         ];
     }
 }

--- a/src/Sitemap/CollectionSitemap.php
+++ b/src/Sitemap/CollectionSitemap.php
@@ -15,7 +15,7 @@ class CollectionSitemap extends BaseSitemap
     public function urls(): Collection
     {
         return $this->entries()
-            ->map(fn ($entry) => (new CollectionSitemapUrl($entry))->toArray())
+            ->map(fn ($entry) => (new CollectionSitemapUrl($entry, $this))->toArray())
             ->filter();
     }
 

--- a/src/Sitemap/CollectionSitemapUrl.php
+++ b/src/Sitemap/CollectionSitemapUrl.php
@@ -50,6 +50,11 @@ class CollectionSitemapUrl extends BaseSitemapUrl
         return number_format($this->entry->seo_sitemap_priority->value(), 1);
     }
 
+    public function site(): string
+    {
+        return $this->entry->site()->handle();
+    }
+
     public function isCanonicalUrl(): bool
     {
         return match ($this->entry->seo_canonical_type->value()) {

--- a/src/Sitemap/CollectionSitemapUrl.php
+++ b/src/Sitemap/CollectionSitemapUrl.php
@@ -10,13 +10,13 @@ use Statamic\Facades\Site;
 
 class CollectionSitemapUrl extends BaseSitemapUrl
 {
-    public function __construct(protected Entry $entry)
+    public function __construct(protected Entry $entry, protected CollectionSitemap $sitemap)
     {
     }
 
     public function loc(): string
     {
-        return $this->entry->absoluteUrl();
+        return $this->absoluteUrl($this->entry);
     }
 
     public function alternates(): ?array
@@ -30,7 +30,7 @@ class CollectionSitemapUrl extends BaseSitemapUrl
 
         return $entries->map(fn ($entry) => [
             'hreflang' => Helpers::parseLocale(Site::get($entry->locale())->locale()),
-            'href' => $entry->absoluteUrl(),
+            'href' => $this->absoluteUrl($entry),
         ])->toArray();
     }
 

--- a/src/Sitemap/CollectionSitemapUrl.php
+++ b/src/Sitemap/CollectionSitemapUrl.php
@@ -19,13 +19,13 @@ class CollectionSitemapUrl extends BaseSitemapUrl
         return $this->entry->absoluteUrl();
     }
 
-    public function alternates(): array
+    public function alternates(): ?array
     {
         $entries = $this->entries();
 
         // We only want alternate URLs if there are at least two entries.
         if ($entries->count() <= 1) {
-            return [];
+            return null;
         }
 
         return $entries->map(fn ($entry) => [

--- a/src/Sitemap/CollectionTaxonomySitemapUrl.php
+++ b/src/Sitemap/CollectionTaxonomySitemapUrl.php
@@ -21,13 +21,13 @@ class CollectionTaxonomySitemapUrl extends BaseSitemapUrl
         return $this->getUrl($this->taxonomy, $this->site);
     }
 
-    public function alternates(): array
+    public function alternates(): ?array
     {
         $taxonomies = $this->taxonomies();
 
         // We only want alternate URLs if there are at least two terms.
         if ($taxonomies->count() <= 1) {
-            return [];
+            return null;
         }
 
         return $taxonomies->map(function ($taxonomy, $site) {

--- a/src/Sitemap/CollectionTaxonomySitemapUrl.php
+++ b/src/Sitemap/CollectionTaxonomySitemapUrl.php
@@ -83,7 +83,7 @@ class CollectionTaxonomySitemapUrl extends BaseSitemapUrl
 
     protected function getUrl(Taxonomy $taxonomy, string $site): string
     {
-        $siteUrl = Site::get($site)->absoluteUrl();
+        $siteUrl = $this->absoluteUrl(Site::get($site));
         $taxonomyHandle = $taxonomy->handle();
         $collectionHandle = $taxonomy->collection()->handle();
 

--- a/src/Sitemap/CollectionTaxonomySitemapUrl.php
+++ b/src/Sitemap/CollectionTaxonomySitemapUrl.php
@@ -57,6 +57,11 @@ class CollectionTaxonomySitemapUrl extends BaseSitemapUrl
         return Defaults::data('taxonomies')->get('seo_sitemap_priority');
     }
 
+    public function site(): string
+    {
+        return $this->site;
+    }
+
     protected function lastModifiedTaxonomyTerm(): ?Term
     {
         return $this->taxonomy->queryTerms()

--- a/src/Sitemap/CollectionTermSitemapUrl.php
+++ b/src/Sitemap/CollectionTermSitemapUrl.php
@@ -15,7 +15,7 @@ class CollectionTermSitemapUrl extends BaseSitemapUrl
 
     public function loc(): string
     {
-        return $this->term->absoluteUrl();
+        return $this->absoluteUrl($this->term);
     }
 
     public function alternates(): ?array
@@ -29,7 +29,7 @@ class CollectionTermSitemapUrl extends BaseSitemapUrl
 
         return $terms->map(fn ($term) => [
             'hreflang' => Helpers::parseLocale(Site::get($term->locale())->locale()),
-            'href' => $term->absoluteUrl(),
+            'href' => $this->absoluteUrl($term),
         ])->toArray();
     }
 

--- a/src/Sitemap/CollectionTermSitemapUrl.php
+++ b/src/Sitemap/CollectionTermSitemapUrl.php
@@ -18,13 +18,13 @@ class CollectionTermSitemapUrl extends BaseSitemapUrl
         return $this->term->absoluteUrl();
     }
 
-    public function alternates(): array
+    public function alternates(): ?array
     {
         $terms = $this->terms();
 
         // We only want alternate URLs if there are at least two terms.
         if ($terms->count() <= 1) {
-            return [];
+            return null;
         }
 
         return $terms->map(fn ($term) => [

--- a/src/Sitemap/CollectionTermSitemapUrl.php
+++ b/src/Sitemap/CollectionTermSitemapUrl.php
@@ -49,6 +49,11 @@ class CollectionTermSitemapUrl extends BaseSitemapUrl
         return number_format($this->term->seo_sitemap_priority->value(), 1);
     }
 
+    public function site(): string
+    {
+        return $this->term->site()->handle();
+    }
+
     public function isCanonicalUrl(): bool
     {
         return match ($this->term->seo_canonical_type->value()) {

--- a/src/Sitemap/CustomSitemapUrl.php
+++ b/src/Sitemap/CustomSitemapUrl.php
@@ -37,21 +37,15 @@ class CustomSitemapUrl extends BaseSitemapUrl
     public function lastmod(Carbon $lastmod = null): string|self|null
     {
         return $this->fluentlyGetOrSet('lastmod')
-            ->getter(function () {
-                return $this->lastmod ?? now()->format('Y-m-d\TH:i:sP');
-            })
-            ->setter(function ($lastmod) {
-                return $lastmod->format('Y-m-d\TH:i:sP');
-            })
+            ->getter(fn () => $this->lastmod ?? now()->format('Y-m-d\TH:i:sP'))
+            ->setter(fn ($lastmod) => $lastmod->format('Y-m-d\TH:i:sP'))
             ->args(func_get_args());
     }
 
     public function changefreq(string $changefreq = null): string|self|null
     {
         return $this->fluentlyGetOrSet('changefreq')
-            ->getter(function () {
-                return $this->changefreq ?? Defaults::data('collections')->get('seo_sitemap_change_frequency');
-            })
+            ->getter(fn () => $this->changefreq ?? Defaults::data('collections')->get('seo_sitemap_change_frequency'))
             ->setter(function ($changefreq) {
                 $allowedValues = ['always', 'hourly', 'daily', 'weekly', 'monthly', 'yearly', 'never'];
                 $allowedValuesString = implode(', ', $allowedValues);
@@ -66,9 +60,7 @@ class CustomSitemapUrl extends BaseSitemapUrl
     public function priority(string $priority = null): string|self|null
     {
         return $this->fluentlyGetOrSet('priority')
-            ->getter(function () {
-                return $this->priority ?? Defaults::data('collections')->get('seo_sitemap_priority');
-            })
+            ->getter(fn () => $this->priority ?? Defaults::data('collections')->get('seo_sitemap_priority'))
             ->setter(function ($priority) {
                 $allowedValues = ['0.0', '0.1', '0.2', '0.3', '0.4', '0.5', '0.6', '0.7', '0.8', '0.9', '1.0'];
                 $allowedValuesString = implode(', ', $allowedValues);

--- a/src/Sitemap/CustomSitemapUrl.php
+++ b/src/Sitemap/CustomSitemapUrl.php
@@ -4,6 +4,7 @@ namespace Aerni\AdvancedSeo\Sitemap;
 
 use Aerni\AdvancedSeo\Models\Defaults;
 use Illuminate\Support\Carbon;
+use Statamic\Facades\Site;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class CustomSitemapUrl extends BaseSitemapUrl
@@ -76,6 +77,13 @@ class CustomSitemapUrl extends BaseSitemapUrl
 
                 return $priority;
             })
+            ->args(func_get_args());
+    }
+
+    public function site(string $site = null): string|self
+    {
+        return $this->fluentlyGetOrSet('site')
+            ->getter(fn () => $this->site ?? Site::default()->handle())
             ->args(func_get_args());
     }
 }

--- a/src/Sitemap/SitemapRepository.php
+++ b/src/Sitemap/SitemapRepository.php
@@ -29,7 +29,7 @@ class SitemapRepository
 
     public function find(string $id): ?Sitemap
     {
-        return $this->all()->first(fn ($sitemap) => $sitemap->id() === $id);
+        return $this->all()->first(fn ($sitemap) => $id === $sitemap->id());
     }
 
     public function clearCache(): void

--- a/src/Sitemap/TaxonomySitemapUrl.php
+++ b/src/Sitemap/TaxonomySitemapUrl.php
@@ -25,7 +25,7 @@ class TaxonomySitemapUrl extends BaseSitemapUrl
 
     public function loc(): string
     {
-        return $this->taxonomy->absoluteUrl();
+        return $this->absoluteUrl($this->taxonomy);
     }
 
     public function alternates(): ?array
@@ -43,7 +43,7 @@ class TaxonomySitemapUrl extends BaseSitemapUrl
 
             return [
                 'hreflang' => Helpers::parseLocale(Site::current()->locale()),
-                'href' => $taxonomy->absoluteUrl(),
+                'href' => $this->absoluteUrl($taxonomy),
             ];
         })->toArray();
     }

--- a/src/Sitemap/TaxonomySitemapUrl.php
+++ b/src/Sitemap/TaxonomySitemapUrl.php
@@ -28,13 +28,13 @@ class TaxonomySitemapUrl extends BaseSitemapUrl
         return $this->taxonomy->absoluteUrl();
     }
 
-    public function alternates(): array
+    public function alternates(): ?array
     {
         $taxonomies = $this->taxonomies();
 
         // We only want alternate URLs if there are at least two terms.
         if ($taxonomies->count() <= 1) {
-            return [];
+            return null;
         }
 
         return $taxonomies->map(function ($taxonomy, $site) {

--- a/src/Sitemap/TaxonomySitemapUrl.php
+++ b/src/Sitemap/TaxonomySitemapUrl.php
@@ -67,6 +67,11 @@ class TaxonomySitemapUrl extends BaseSitemapUrl
         return Defaults::data('taxonomies')->get('seo_sitemap_priority');
     }
 
+    public function site(): string
+    {
+        return $this->site;
+    }
+
     protected function lastModifiedTaxonomyTerm(): ?Term
     {
         return $this->taxonomy->queryTerms()

--- a/src/Sitemap/TermSitemapUrl.php
+++ b/src/Sitemap/TermSitemapUrl.php
@@ -15,7 +15,7 @@ class TermSitemapUrl extends BaseSitemapUrl
 
     public function loc(): string
     {
-        return $this->term->absoluteUrl();
+        return $this->absoluteUrl($this->term);
     }
 
     public function alternates(): ?array
@@ -29,7 +29,7 @@ class TermSitemapUrl extends BaseSitemapUrl
 
         return $terms->map(fn ($term) => [
             'hreflang' => Helpers::parseLocale(Site::get($term->locale())->locale()),
-            'href' => $term->absoluteUrl(),
+            'href' => $this->absoluteUrl($term),
         ])->toArray();
     }
 

--- a/src/Sitemap/TermSitemapUrl.php
+++ b/src/Sitemap/TermSitemapUrl.php
@@ -49,6 +49,11 @@ class TermSitemapUrl extends BaseSitemapUrl
         return number_format($this->term->seo_sitemap_priority->value(), 1);
     }
 
+    public function site(): string
+    {
+        return $this->term->site()->handle();
+    }
+
     public function isCanonicalUrl(): bool
     {
         return match ($this->term->seo_canonical_type->value()) {

--- a/src/Sitemap/TermSitemapUrl.php
+++ b/src/Sitemap/TermSitemapUrl.php
@@ -18,13 +18,13 @@ class TermSitemapUrl extends BaseSitemapUrl
         return $this->term->absoluteUrl();
     }
 
-    public function alternates(): array
+    public function alternates(): ?array
     {
         $terms = $this->terms();
 
         // We only want alternate URLs if there are at least two terms.
         if ($terms->count() <= 1) {
-            return [];
+            return null;
         }
 
         return $terms->map(fn ($term) => [

--- a/src/View/BaseCascade.php
+++ b/src/View/BaseCascade.php
@@ -18,8 +18,8 @@ use Statamic\Tags\Context;
 
 abstract class BaseCascade implements Augmentable
 {
-    use HasAugmentedInstance;
     use ContainsData;
+    use HasAugmentedInstance;
 
     public function __construct(protected Context|DefaultsData|Entry|Term $model)
     {

--- a/src/View/GraphQlCascade.php
+++ b/src/View/GraphQlCascade.php
@@ -2,6 +2,7 @@
 
 namespace Aerni\AdvancedSeo\View;
 
+use Aerni\AdvancedSeo\Concerns\HasBaseUrl;
 use Aerni\AdvancedSeo\Data\HasComputedData;
 use Aerni\AdvancedSeo\Facades\SocialImage;
 use Aerni\AdvancedSeo\Support\Helpers;
@@ -16,9 +17,7 @@ use Statamic\Support\Str;
 
 class GraphQlCascade extends BaseCascade
 {
-    use HasComputedData;
-
-    protected ?string $baseUrl = null;
+    use HasBaseUrl, HasComputedData;
 
     public function __construct(Entry|Term $model)
     {
@@ -162,10 +161,10 @@ class GraphQlCascade extends BaseCascade
             ->filter(fn ($model) => $model->published()) // Remove any unpublished entries/terms
             ->filter(fn ($model) => $model->url()) // Remove any entries/terms with no route
             ->map(fn ($model) => [
-                'url' => $this->buildUrl($model),
+                'url' => $this->absoluteUrl($model),
                 'locale' => Helpers::parseLocale($model->site()->locale()),
             ])->push([
-                'url' => $this->buildUrl($root),
+                'url' => $this->absoluteUrl($root),
                 'locale' => 'x-default',
             ])->all();
 
@@ -177,14 +176,14 @@ class GraphQlCascade extends BaseCascade
         $type = $this->get('canonical_type');
 
         if ($type == 'other' && $this->has('canonical_entry')) {
-            return $this->buildUrl($this->get('canonical_entry'));
+            return $this->absoluteUrl($this->get('canonical_entry'));
         }
 
         if ($type == 'custom' && $this->has('canonical_custom')) {
             return $this->get('canonical_custom');
         }
 
-        return $this->buildUrl($this->model);
+        return $this->absoluteUrl($this->model);
     }
 
     public function siteSchema(): ?string
@@ -202,11 +201,11 @@ class GraphQlCascade extends BaseCascade
         if ($type == 'organization') {
             $schema = Schema::organization()
                 ->name($this->get('organization_name'))
-                ->url($this->buildUrl($this->model->site()));
+                ->url($this->absoluteUrl($this->model->site()));
 
             if ($logo = $this->get('organization_logo')) {
                 $logo = Schema::imageObject()
-                    ->url($this->buildUrl($logo))
+                    ->url($this->absoluteUrl($logo))
                     ->width($logo->width())
                     ->height($logo->height());
 
@@ -217,7 +216,7 @@ class GraphQlCascade extends BaseCascade
         if ($type == 'person') {
             $schema = Schema::person()
                 ->name($this->get('person_name'))
-                ->url($this->buildUrl($this->model->site()));
+                ->url($this->absoluteUrl($this->model->site()));
         }
 
         return json_encode($schema->toArray(), JSON_UNESCAPED_UNICODE);
@@ -263,23 +262,16 @@ class GraphQlCascade extends BaseCascade
             ->map(fn ($model, $key) => [
                 'position' => $key + 1,
                 'title' => method_exists($model, 'title') ? $model->title() : $model->value('title'),
-                'url' => $this->buildUrl($model),
+                'url' => $this->absoluteUrl($model),
             ]);
 
         return $crumbs;
     }
 
-    public function baseUrl(?string $baseUrl): self
+    protected function absoluteUrl(mixed $model): ?string
     {
-        $this->baseUrl = $baseUrl;
-
-        return $this;
-    }
-
-    protected function buildUrl(mixed $model): ?string
-    {
-        return $this->baseUrl
-            ? URL::assemble($this->baseUrl, $model->url())
+        return $this->baseUrl()
+            ? URL::assemble($this->baseUrl(), $model->url())
             : $model->absoluteUrl();
     }
 }


### PR DESCRIPTION
This PR adds GraphQL support for sitemaps.

A basic query looks like this:

```graphql
query MyQuery {
  seoSitemap {
    alternates {
      href
      hreflang
    }
    changefreq
    lastmod
    loc
    priority
  }
}
```

You can also filter by `site`:

```graphql
query MyQuery {
  seoSitemap(site: "default") {
    loc
  }
}
```

It's also possible to filter by `type` and `handle`. Possible values for `type` are `collection`, `taxonomy`, and `custom`.

```graphql
query MyQuery {
  seoSitemap(type: "collection", handle: "pages") {
    loc
  }
}
```

You may also change the `baseUrl` like this:

```graphql
query MyQuery {
  seoSitemap(baseUrl: "https://foo.bar") {
    loc
  }
}
```
