### PR TITLE
Fix policy with users in database

### DIFF
--- a/src/Policies/SeoVariablesPolicy.php
+++ b/src/Policies/SeoVariablesPolicy.php
@@ -3,28 +3,27 @@
 namespace Aerni\AdvancedSeo\Policies;
 
 use Aerni\AdvancedSeo\Models\Defaults;
-use Statamic\Contracts\Auth\User;
-use Statamic\Facades\User as UserFacade;
+use Statamic\Facades\User;
 
 class SeoVariablesPolicy
 {
-    public function index(User $user, string $type): bool
+    public function index($user, string $type): bool
     {
         return Defaults::enabledInType($type)->map->handle
             ->filter(fn ($type) => $this->view($user, $type))
             ->isNotEmpty();
     }
 
-    public function view(User $user, string $type): bool
+    public function view($user, string $type): bool
     {
-        $user = UserFacade::fromUser($user);
+        $user = User::fromUser($user);
 
         return $user->hasPermission("view seo {$type} defaults");
     }
 
-    public function edit(User $user, string $type): bool
+    public function edit($user, string $type): bool
     {
-        $user = UserFacade::fromUser($user);
+        $user = User::fromUser($user);
 
         return $user->hasPermission("edit seo {$type} defaults");
     }


### PR DESCRIPTION
This PR fixes issue #108 by removing the type of the `$user`. If users are in the database, the type will be `App\Models\User` as opposed to `Statamic\Contracts\Auth\User` when using file users.