### PR TITLE
Always create Value from raw data

### DIFF
--- a/src/Actions/EvaluateFeature.php
+++ b/src/Actions/EvaluateFeature.php
@@ -7,7 +7,7 @@ use Statamic\Facades\Blink;
 
 class EvaluateFeature
 {
-    public static function handle(string $feature, DefaultsData $data = null): bool
+    public static function handle(string $feature, ?DefaultsData $data = null): bool
     {
         return $data
             ? Blink::once("advanced-seo::features::{$feature}::{$data->id()}", fn () => resolve($feature)::enabled($data))

--- a/src/Actions/GetSiteDefaults.php
+++ b/src/Actions/GetSiteDefaults.php
@@ -17,6 +17,10 @@ class GetSiteDefaults
             return collect();
         }
 
+        /**
+         * TODO: Instead of using the overriding code at the bottom, we might be able to refactor this to something similar to the GetPageData action.
+         * Instead of augmenting all the default values upfront, we could get the blueprint of each site default and then add the values to each blueprint field.
+         */
         return Blink::once("advanced-seo::site::{$locale}", function () use ($locale, $data) {
             $siteDefaults = Defaults::enabledInType('site')
                 ->flatMap(fn ($model) => GetAugmentedDefaults::handle(
@@ -35,7 +39,7 @@ class GetSiteDefaults
              */
             $overrides = $siteDefaults->intersectByKeys($data)
                 ->map(fn ($originalValue, $key) => new Value(
-                    value: $data->get($key),
+                    value: ($value = $data->get($key)) instanceof Value ? $value->raw() : $value,
                     handle: $originalValue->handle(),
                     fieldtype: $originalValue->fieldtype(),
                     augmentable: $originalValue->augmentable()

--- a/src/Actions/Indexable.php
+++ b/src/Actions/Indexable.php
@@ -10,7 +10,7 @@ use Statamic\Facades\Blink;
 
 class Indexable
 {
-    public static function handle(Entry|Term|Taxonomy $model, string $locale = null): bool
+    public static function handle(Entry|Term|Taxonomy $model, ?string $locale = null): bool
     {
         $locale = $locale ?? $model->locale();
 

--- a/src/Concerns/HasBaseUrl.php
+++ b/src/Concerns/HasBaseUrl.php
@@ -10,7 +10,7 @@ trait HasBaseUrl
 
     protected ?string $baseUrl = null;
 
-    public function baseUrl(string $baseUrl = null): self|string|null
+    public function baseUrl(?string $baseUrl = null): self|string|null
     {
         return $this->fluentlyGetOrSet('baseUrl')->args(func_get_args());
     }

--- a/src/Concerns/HasDefaultsData.php
+++ b/src/Concerns/HasDefaultsData.php
@@ -8,7 +8,7 @@ trait HasDefaultsData
 {
     protected $defaultsData;
 
-    public function defaultsData(DefaultsData $data = null): DefaultsData|self
+    public function defaultsData(?DefaultsData $data = null): DefaultsData|self
     {
         return $this->fluentlyGetOrSet('defaultsData')
             ->getter(function ($data) {

--- a/src/Fieldtypes/CascadeFieldtype.php
+++ b/src/Fieldtypes/CascadeFieldtype.php
@@ -8,7 +8,7 @@ class CascadeFieldtype extends Fieldtype
 {
     protected $selectable = false;
 
-    public function config(string $key = null, $fallback = null)
+    public function config(?string $key = null, $fallback = null)
     {
         $config = collect([
             'antlers' => true,

--- a/src/Migrators/AardvarkSeoMigrator.php
+++ b/src/Migrators/AardvarkSeoMigrator.php
@@ -36,7 +36,7 @@ class AardvarkSeoMigrator extends BaseMigrator
         ]);
     }
 
-    protected function transform(Collection $data, Collection $oldData = null): Collection
+    protected function transform(Collection $data, ?Collection $oldData = null): Collection
     {
         $transformed = collect([
             'seo_json_ld' => $data->has('seo_json_ld') ? $this->transformJsonLd($data->get('seo_json_ld')) : null,

--- a/src/Migrators/BaseMigrator.php
+++ b/src/Migrators/BaseMigrator.php
@@ -60,7 +60,7 @@ abstract class BaseMigrator
      * We are piping the data through this method to transform
      * any values that need to be different and also add new ones.
      */
-    protected function transform(Collection $data, Collection $oldData = null): Collection
+    protected function transform(Collection $data, ?Collection $oldData = null): Collection
     {
         return $data;
     }

--- a/src/Migrators/SeoProMigrator.php
+++ b/src/Migrators/SeoProMigrator.php
@@ -43,7 +43,7 @@ class SeoProMigrator extends BaseMigrator
             ->pipe(fn ($data) => $this->transform($data, $oldData));
     }
 
-    protected function transform(Collection $data, Collection $oldData = null): Collection
+    protected function transform(Collection $data, ?Collection $oldData = null): Collection
     {
         $robots = Arr::get($oldData, 'robots', []);
         $image = Arr::get($oldData, 'image');

--- a/src/Sitemap/CustomSitemapUrl.php
+++ b/src/Sitemap/CustomSitemapUrl.php
@@ -15,12 +15,12 @@ class CustomSitemapUrl extends BaseSitemapUrl
     {
     }
 
-    public function loc(string $loc = null): string|self
+    public function loc(?string $loc = null): string|self
     {
         return $this->fluentlyGetOrSet('loc')->args(func_get_args());
     }
 
-    public function alternates(array $alternates = null): array|self|null
+    public function alternates(?array $alternates = null): array|self|null
     {
         return $this->fluentlyGetOrSet('alternates')
             ->setter(function ($alternates) {
@@ -34,7 +34,7 @@ class CustomSitemapUrl extends BaseSitemapUrl
             ->args(func_get_args());
     }
 
-    public function lastmod(Carbon $lastmod = null): string|self|null
+    public function lastmod(?Carbon $lastmod = null): string|self|null
     {
         return $this->fluentlyGetOrSet('lastmod')
             ->getter(fn () => $this->lastmod ?? now()->format('Y-m-d\TH:i:sP'))
@@ -42,7 +42,7 @@ class CustomSitemapUrl extends BaseSitemapUrl
             ->args(func_get_args());
     }
 
-    public function changefreq(string $changefreq = null): string|self|null
+    public function changefreq(?string $changefreq = null): string|self|null
     {
         return $this->fluentlyGetOrSet('changefreq')
             ->getter(fn () => $this->changefreq ?? Defaults::data('collections')->get('seo_sitemap_change_frequency'))
@@ -57,7 +57,7 @@ class CustomSitemapUrl extends BaseSitemapUrl
             ->args(func_get_args());
     }
 
-    public function priority(string $priority = null): string|self|null
+    public function priority(?string $priority = null): string|self|null
     {
         return $this->fluentlyGetOrSet('priority')
             ->getter(fn () => $this->priority ?? Defaults::data('collections')->get('seo_sitemap_priority'))
@@ -72,7 +72,7 @@ class CustomSitemapUrl extends BaseSitemapUrl
             ->args(func_get_args());
     }
 
-    public function site(string $site = null): string|self
+    public function site(?string $site = null): string|self
     {
         return $this->fluentlyGetOrSet('site')
             ->getter(fn () => $this->site ?? Site::default()->handle())


### PR DESCRIPTION
This PR closes #93 by ensuring that we create override values from raw data. There might be cases, where the value is a `\Statamic\Fields\Value` object instead of a simple value like a string. If we don't use the raw data of the given Value object, we'll end up with the Value object as the raw data of the new Value object. Which leads to unwanted behavior when we later call the `value()` method on the new Value object.