### PR TITLE
Fix policy 

### DIFF
--- a/src/Models/Defaults.php
+++ b/src/Models/Defaults.php
@@ -26,7 +26,7 @@ class Defaults extends Model
                 'enabled' => true,
                 'icon' => 'icons/light/sites',
                 'type_icon' => 'earth',
-                'set' => Seo::findById('site::general'),
+                'set' => Seo::findOrMake('site', 'general'),
             ],
             [
                 'id' => 'site::indexing',
@@ -38,7 +38,7 @@ class Defaults extends Model
                 'enabled' => true,
                 'icon' => 'icons/light/structures',
                 'type_icon' => 'earth',
-                'set' => Seo::findById('site::indexing'),
+                'set' => Seo::findOrMake('site', 'indexing'),
             ],
             [
                 'id' => 'site::social_media',
@@ -50,7 +50,7 @@ class Defaults extends Model
                 'enabled' => true,
                 'icon' => 'icons/light/assets',
                 'type_icon' => 'earth',
-                'set' => Seo::findById('site::social_media'),
+                'set' => Seo::findOrMake('site', 'social_media'),
             ],
             [
                 'id' => 'site::analytics',
@@ -62,7 +62,7 @@ class Defaults extends Model
                 'enabled' => collect(config('advanced-seo.analytics'))->reject(fn ($value, $key) => $key === 'environments')->filter()->isNotEmpty(),
                 'icon' => 'icons/light/charts',
                 'type_icon' => 'earth',
-                'set' => Seo::findById('site::analytics'),
+                'set' => Seo::findOrMake('site', 'analytics'),
             ],
             [
                 'id' => 'site::favicons',
@@ -74,7 +74,7 @@ class Defaults extends Model
                 'enabled' => config('advanced-seo.favicons.enabled', false),
                 'icon' => 'icons/light/color',
                 'type_icon' => 'earth',
-                'set' => Seo::findById('site::favicons'),
+                'set' => Seo::findOrMake('site', 'favicons'),
             ],
         ];
 
@@ -89,7 +89,7 @@ class Defaults extends Model
                 'enabled' => ! in_array($collection->handle(), config('advanced-seo.disabled.collections', [])),
                 'icon' => 'icons/light/content-writing',
                 'type_icon' => 'content-writing',
-                'set' => Seo::findById('collections::'.$collection->handle()),
+                'set' => Seo::findOrMake('collections', $collection->handle()),
             ];
         })->sortBy('handle');
 
@@ -104,7 +104,7 @@ class Defaults extends Model
                 'enabled' => ! in_array($taxonomy->handle(), config('advanced-seo.disabled.taxonomies', [])),
                 'icon' => 'icons/light/tags',
                 'type_icon' => 'tags',
-                'set' => Seo::findById('taxonomies::'.$taxonomy->handle()),
+                'set' => Seo::findOrMake('taxonomies', $taxonomy->handle()),
             ];
         })->sortBy('handle');
 

--- a/src/Stache/SeoDefaultsRepository.php
+++ b/src/Stache/SeoDefaultsRepository.php
@@ -32,14 +32,6 @@ class SeoDefaultsRepository implements Contract
         return $this->store->store($type)->getItem($handle);
     }
 
-    public function findById(string $id): ?SeoDefaultSet
-    {
-        $type = Str::before($id, '::');
-        $handle = Str::after($id, '::');
-
-        return $this->find($type, $handle);
-    }
-
     public function findOrMake(string $type, string $handle): SeoDefaultSet
     {
         return $this->find($type, $handle) ?? $this->make()->type($type)->handle($handle);

--- a/src/Stache/SeoDefaultsRepository.php
+++ b/src/Stache/SeoDefaultsRepository.php
@@ -5,7 +5,6 @@ namespace Aerni\AdvancedSeo\Stache;
 use Aerni\AdvancedSeo\Contracts\SeoDefaultsRepository as Contract;
 use Aerni\AdvancedSeo\Data\SeoDefaultSet;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 use Statamic\Data\DataCollection;
 use Statamic\Stache\Stache;
 use Statamic\Stache\Stores\Store;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -79,7 +79,7 @@ class TestCase extends OrchestraTestCase
         ];
 
         foreach ($configs as $config) {
-            $app['config']->set("statamic.$config", require(__DIR__."/../vendor/statamic/cms/config/{$config}.php"));
+            $app['config']->set("statamic.$config", require (__DIR__."/../vendor/statamic/cms/config/{$config}.php"));
         }
 
         // Creat two site for multi site testing
@@ -110,6 +110,6 @@ class TestCase extends OrchestraTestCase
         $app['config']->set('statamic.git.enabled', true);
 
         // Define the addon config for our tests
-        $app['config']->set('advanced-seo', require(__DIR__.'/../config/advanced-seo.php'));
+        $app['config']->set('advanced-seo', require (__DIR__.'/../config/advanced-seo.php'));
     }
 }


### PR DESCRIPTION
This PR closes #118. The issue was triggered when checking for the user's permissions while booting the addon's CP navigation. The `SeoVariablesPolicy` requires existing `SeoDefaultSet` to determine a user's permissions. So if you don't have any SEO sets saved to file yet, you would run into this issue. We can easily fix this by ensuring we always have a set to work with, even if it's not saved to file yet.