### PR TITLE
Fix interface

### DIFF
--- a/src/Contracts/SeoDefaultsRepository.php
+++ b/src/Contracts/SeoDefaultsRepository.php
@@ -12,8 +12,6 @@ interface SeoDefaultsRepository
 
     public function find(string $type, string $handle): ?SeoDefaultSet;
 
-    public function findById(string $id): ?SeoDefaultSet;
-
     public function findOrMake(string $type, string $handle): SeoDefaultSet;
 
     public function all(): Collection;


### PR DESCRIPTION
Missed to delete the removed `findById` method from the interface in PR #120.