### PR TITLE
Strip Tags from title and description 

### DIFF
--- a/resources/views/snippets/_basic.antlers.html
+++ b/resources/views/snippets/_basic.antlers.html
@@ -1,7 +1,7 @@
 {{ if seo:title }}
-    <title>{{ seo:title }}</title>
+    <title>{{ seo:title | strip_tags }}</title>
 {{ /if }}
 
 {{ if seo:description }}
-    <meta name="description" content="{{ seo:description }}">
+    <meta name="description" content="{{ seo:description | strip_tags }}">
 {{ /if }}

--- a/resources/views/snippets/_open_graph.antlers.html
+++ b/resources/views/snippets/_open_graph.antlers.html
@@ -9,7 +9,7 @@
 {{ /if }}
 
 {{ if seo:og_title }}
-    <meta property="og:title" content="{{ seo:og_title }}">
+    <meta property="og:title" content="{{ seo:og_title | strip_tags }}">
 {{ /if }}
 
 {{ if seo:canonical }}
@@ -23,7 +23,7 @@
 {{ /if }}
 
 {{ if seo:og_description }}
-    <meta property="og:description" content="{{ seo:og_description }}">
+    <meta property="og:description" content="{{ seo:og_description | strip_tags }}">
 {{ /if }}
 
 {{ if seo:og_image }}

--- a/resources/views/snippets/_twitter.antlers.html
+++ b/resources/views/snippets/_twitter.antlers.html
@@ -3,11 +3,11 @@
 {{ /if }}
 
 {{ if seo:twitter_title }}
-    <meta name="twitter:title" content="{{ seo:twitter_title }}">
+    <meta name="twitter:title" content="{{ seo:twitter_title | strip_tags }}">
 {{ /if }}
 
 {{ if seo:twitter_description }}
-    <meta name="twitter:description" content="{{ seo:twitter_description }}">
+    <meta name="twitter:description" content="{{ seo:twitter_description | strip_tags }}">
 {{ /if }}
 
 {{ if seo:twitter_handle }}


### PR DESCRIPTION
In some cases, titles and descriptions are taken directly from markdown fields. In my case, for example, I had the problem of p and strong tags being written in the meta title and meta description. I tried putting in the defaults {{ title | strip_tags }} but it didn't seem to work, so I thought I would come up with this pull request.