### PR TITLE
Fix issue on disabled collection routes

### DIFF
--- a/src/View/ViewCascade.php
+++ b/src/View/ViewCascade.php
@@ -232,7 +232,7 @@ class ViewCascade extends BaseCascade
         }
 
         // Handle entries and term show page.
-        $data = Data::find($this->model->get('id'));
+        $data = Data::find($this->model->value('id'));
 
         if (! $data) {
             return null;


### PR DESCRIPTION
This PR resolves an issue where you would run into the following exception that would be thrown when visiting an entry whose collection has been disabled in the Advanced SEO config and whose view includes a `{{ nav }}` tag that loops over entries of another collection, which is enabled for Advanced SEO.

![CleanShot 2024-05-10 at 10 49 17@2x](https://github.com/aerni/statamic-advanced-seo/assets/23167701/e844e8ad-ee13-47ed-be88-f39d48ab1323)
