### PR TITLE
Respect order of sites as defined in the config

### DIFF
--- a/src/Data/SeoDefaultSet.php
+++ b/src/Data/SeoDefaultSet.php
@@ -61,7 +61,7 @@ class SeoDefaultSet implements Contract
 
         if ($parent = $this->parent()) {
             // Only return sites from the parent that are configured in Statamic's sites config
-            return $parent->sites()->intersect($allSites)->values();
+            return $allSites->filter(fn ($site) => $parent->sites()->contains($site));
         }
 
         return $allSites;


### PR DESCRIPTION
This PR ensures that the sites in the sidebar of the SEO defaults settings are always ordered according to the order defined in Statamic's sites config.