### PR TITLE
Respect the content's site when generating social images

### DIFF
--- a/resources/stubs/social_images/layout.antlers.html
+++ b/resources/stubs/social_images/layout.antlers.html
@@ -6,7 +6,7 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="{{ mix src='css/tailwind.css' }}">
+        {{ vite src="resources/css/site.css" }}
         <style>.phpdebugbar { display: none !important; }</style>
     </head>
 

--- a/src/Http/Controllers/Web/SocialImagesController.php
+++ b/src/Http/Controllers/Web/SocialImagesController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Data;
+use Statamic\Facades\Site;
 use Statamic\Taxonomies\LocalizedTerm;
 use Statamic\View\View;
 
@@ -35,6 +36,8 @@ class SocialImagesController extends Controller
 
         // Prevent an infinite loop when an image is generated in the augment method of the SocialImageFieldtype.
         $data->set('seo_generate_social_images', false);
+
+        Site::setCurrent($data->site()->handle());
 
         $view = (new View)
             ->template($template)


### PR DESCRIPTION
This PR ensures that we are using the correct site when generating the social images. Previously, it would always use the default site. This fix was only possible because of https://github.com/statamic/cms/pull/10109.

This PR also updates the layout stub to use the `{{ vite }}` tag.