### PR TITLE
Fix preview targets issue on certain routes

### DIFF
--- a/src/Subscribers/SocialImagesGeneratorSubscriber.php
+++ b/src/Subscribers/SocialImagesGeneratorSubscriber.php
@@ -2,20 +2,18 @@
 
 namespace Aerni\AdvancedSeo\Subscribers;
 
-use Statamic\Events;
-use Statamic\Statamic;
-use Statamic\Events\Event;
-use Statamic\Facades\Site;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Statamic\Facades\CP\Toast;
-use Illuminate\Events\Dispatcher;
-use Aerni\AdvancedSeo\Facades\SocialImage;
+use Aerni\AdvancedSeo\Actions\ShouldGenerateSocialImages;
 use Aerni\AdvancedSeo\Concerns\GetsEventData;
+use Aerni\AdvancedSeo\Facades\SocialImage;
+use Aerni\AdvancedSeo\Features\SocialImagesGenerator;
 use Aerni\AdvancedSeo\Jobs\DeleteSocialImagesJob;
 use Aerni\AdvancedSeo\Jobs\GenerateSocialImagesJob;
-use Aerni\AdvancedSeo\Features\SocialImagesGenerator;
-use Aerni\AdvancedSeo\Actions\ShouldGenerateSocialImages;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Support\Str;
+use Statamic\Events;
+use Statamic\Events\Event;
+use Statamic\Facades\CP\Toast;
+use Statamic\Statamic;
 
 class SocialImagesGeneratorSubscriber
 {


### PR DESCRIPTION
This PR fixes #147. The issue was caused because the `$entry->seo_social_images_theme` field was requested on routes where it isn't added to the blueprint. We are resolving this issue by only adding to the preview targets when it's actually needed, at which point the field has been added to the blueprint as well.