### PR TITLE
Refactor blueprint extension

### DIFF
--- a/src/Actions/EvaluateModelLocale.php
+++ b/src/Actions/EvaluateModelLocale.php
@@ -24,10 +24,10 @@ class EvaluateModelLocale
             ($model instanceof SeoDefaultSet) => self::seoDefaultSet($model),
             ($model instanceof Collection) => self::collection(),
             ($model instanceof Entry) => $model->locale(),
-            ($model instanceof EntryBlueprintFound) => self::entryBlueprintFound(),
+            ($model instanceof EntryBlueprintFound) => self::entryBlueprintFound($model),
             ($model instanceof Taxonomy) => self::taxonomy(),
             ($model instanceof Term) => self::term($model),
-            ($model instanceof TermBlueprintFound) => self::termBlueprintFound(),
+            ($model instanceof TermBlueprintFound) => self::termBlueprintFound($model),
             ($model instanceof Context) => $model->get('site')?->handle() ?? Site::current()->handle(),
             ($model instanceof DefaultsData) => $model->locale,
             default => null
@@ -60,11 +60,29 @@ class EvaluateModelLocale
         return Site::selected()->handle();
     }
 
-    protected static function entryBlueprintFound(): string
+    protected static function entryBlueprintFound(EntryBlueprintFound $model): string
     {
-        return Statamic::isCpRoute()
-            ? basename(request()->path())
-            : Site::current()->handle();
+        // If we're not in the CP, simply return the current locale.
+        if (! Statamic::isCpRoute()) {
+            return Site::current()->handle();
+        }
+
+        $requestLocale = request()->get('site');
+
+        // If the request contains a valid site, use it.
+        if ($model->blueprint->parent()->sites()->contains($requestLocale)) {
+            return $requestLocale;
+        };
+
+        $pathLocale = basename(request()->path());
+
+        // If the request path is a valid site, use it.
+        if ($model->blueprint->parent()->sites()->contains($pathLocale)) {
+            return $pathLocale;
+        };
+
+        // Return the selected site if no locale has been evaluated so far.
+        return Site::selected()->handle();
     }
 
     protected static function taxonomy(): string
@@ -81,10 +99,28 @@ class EvaluateModelLocale
             : $model->locale();
     }
 
-    protected static function termBlueprintFound(): string
+    protected static function termBlueprintFound(TermBlueprintFound $model): string
     {
-        return Statamic::isCpRoute()
-            ? basename(request()->path())
-            : Site::current()->handle();
+        // If we're not in the CP, simply return the current locale.
+        if (! Statamic::isCpRoute()) {
+            return Site::current()->handle();
+        }
+
+        $requestLocale = request()->get('site');
+
+        // If the request contains a valid site, use it.
+        if ($model->blueprint->parent()->sites()->contains($requestLocale)) {
+            return $requestLocale;
+        };
+
+        $pathLocale = basename(request()->path());
+
+        // If the request path is a valid site, use it.
+        if ($model->blueprint->parent()->sites()->contains($pathLocale)) {
+            return $pathLocale;
+        };
+
+        // Return the selected site if no locale has been evaluated so far.
+        return Site::selected()->handle();
     }
 }

--- a/src/Actions/EvaluateModelLocale.php
+++ b/src/Actions/EvaluateModelLocale.php
@@ -2,19 +2,20 @@
 
 namespace Aerni\AdvancedSeo\Actions;
 
-use Aerni\AdvancedSeo\Data\DefaultsData;
-use Aerni\AdvancedSeo\Data\SeoDefaultSet;
-use Illuminate\Support\Str;
-use Statamic\Contracts\Entries\Collection;
-use Statamic\Contracts\Entries\Entry;
-use Statamic\Contracts\Taxonomies\Taxonomy;
-use Statamic\Contracts\Taxonomies\Term;
-use Statamic\Events\EntryBlueprintFound;
-use Statamic\Events\TermBlueprintFound;
-use Statamic\Facades\Entry as EntryFacade;
-use Statamic\Facades\Site;
 use Statamic\Statamic;
+use Statamic\Facades\Site;
 use Statamic\Tags\Context;
+use Illuminate\Support\Str;
+use Statamic\Taxonomies\Term;
+use Statamic\Contracts\Entries\Entry;
+use Statamic\Taxonomies\LocalizedTerm;
+use Statamic\Events\TermBlueprintFound;
+use Aerni\AdvancedSeo\Data\DefaultsData;
+use Statamic\Events\EntryBlueprintFound;
+use Aerni\AdvancedSeo\Data\SeoDefaultSet;
+use Statamic\Contracts\Entries\Collection;
+use Statamic\Facades\Entry as EntryFacade;
+use Statamic\Contracts\Taxonomies\Taxonomy;
 
 class EvaluateModelLocale
 {
@@ -27,6 +28,7 @@ class EvaluateModelLocale
             ($model instanceof EntryBlueprintFound) => self::entryBlueprintFound($model),
             ($model instanceof Taxonomy) => self::taxonomy(),
             ($model instanceof Term) => self::term($model),
+            ($model instanceof LocalizedTerm) => $model->locale(),
             ($model instanceof TermBlueprintFound) => self::termBlueprintFound($model),
             ($model instanceof Context) => $model->get('site')?->handle() ?? Site::current()->handle(),
             ($model instanceof DefaultsData) => $model->locale,
@@ -72,14 +74,14 @@ class EvaluateModelLocale
         // If the request contains a valid site, use it.
         if ($model->blueprint->parent()->sites()->contains($requestLocale)) {
             return $requestLocale;
-        };
+        }
 
         $pathLocale = basename(request()->path());
 
         // If the request path is a valid site, use it.
         if ($model->blueprint->parent()->sites()->contains($pathLocale)) {
             return $pathLocale;
-        };
+        }
 
         // Return the selected site if no locale has been evaluated so far.
         return Site::selected()->handle();
@@ -94,6 +96,10 @@ class EvaluateModelLocale
 
     protected static function term(Term $model): string
     {
+        /**
+         * In the CP, a term always returns the default locale, no matter which locale is being viewed.
+         * As a workaround, we are getting the locale from the path instead.
+         */
         return Statamic::isCpRoute()
             ? basename(request()->path())
             : $model->locale();
@@ -111,14 +117,14 @@ class EvaluateModelLocale
         // If the request contains a valid site, use it.
         if ($model->blueprint->parent()->sites()->contains($requestLocale)) {
             return $requestLocale;
-        };
+        }
 
         $pathLocale = basename(request()->path());
 
         // If the request path is a valid site, use it.
         if ($model->blueprint->parent()->sites()->contains($pathLocale)) {
             return $pathLocale;
-        };
+        }
 
         // Return the selected site if no locale has been evaluated so far.
         return Site::selected()->handle();

--- a/src/Actions/EvaluateModelLocale.php
+++ b/src/Actions/EvaluateModelLocale.php
@@ -2,20 +2,20 @@
 
 namespace Aerni\AdvancedSeo\Actions;
 
-use Statamic\Statamic;
-use Statamic\Facades\Site;
-use Statamic\Tags\Context;
-use Illuminate\Support\Str;
-use Statamic\Taxonomies\Term;
-use Statamic\Contracts\Entries\Entry;
-use Statamic\Taxonomies\LocalizedTerm;
-use Statamic\Events\TermBlueprintFound;
 use Aerni\AdvancedSeo\Data\DefaultsData;
-use Statamic\Events\EntryBlueprintFound;
 use Aerni\AdvancedSeo\Data\SeoDefaultSet;
+use Illuminate\Support\Str;
 use Statamic\Contracts\Entries\Collection;
-use Statamic\Facades\Entry as EntryFacade;
+use Statamic\Contracts\Entries\Entry;
 use Statamic\Contracts\Taxonomies\Taxonomy;
+use Statamic\Events\EntryBlueprintFound;
+use Statamic\Events\TermBlueprintFound;
+use Statamic\Facades\Entry as EntryFacade;
+use Statamic\Facades\Site;
+use Statamic\Statamic;
+use Statamic\Tags\Context;
+use Statamic\Taxonomies\LocalizedTerm;
+use Statamic\Taxonomies\Term;
 
 class EvaluateModelLocale
 {

--- a/src/Support/Helpers.php
+++ b/src/Support/Helpers.php
@@ -2,9 +2,8 @@
 
 namespace Aerni\AdvancedSeo\Support;
 
-use Aerni\AdvancedSeo\Data\DefaultsData;
-use Statamic\Statamic;
 use Illuminate\Support\Str;
+use Statamic\Statamic;
 
 class Helpers
 {

--- a/src/Support/Helpers.php
+++ b/src/Support/Helpers.php
@@ -2,6 +2,7 @@
 
 namespace Aerni\AdvancedSeo\Support;
 
+use Aerni\AdvancedSeo\Data\DefaultsData;
 use Statamic\Statamic;
 use Illuminate\Support\Str;
 
@@ -14,9 +15,9 @@ class Helpers
         return \WhiteCube\Lingua\Service::create($parsed)->toW3C();
     }
 
-    public static function isActionCpRoute(): bool
+    public static function isDisabled(string $type, string $handle): bool
     {
-        return Statamic::isCpRoute() && Str::contains(request()->path(), 'actions');
+        return in_array($handle, config("advanced-seo.disabled.{$type}", []));
     }
 
     public static function isAddonCpRoute(): bool
@@ -29,24 +30,9 @@ class Helpers
         return Statamic::isCpRoute() && Str::contains(request()->path(), 'blueprints');
     }
 
-    public static function isEntryCreateRoute(): bool
-    {
-        return request()->route()?->getName() === 'statamic.cp.collections.entries.create';
-    }
-
     public static function isEntryEditRoute(): bool
     {
         return request()->route()?->getName() === 'statamic.cp.collections.entries.edit';
-    }
-
-    public static function isTermCreateRoute(): bool
-    {
-        return request()->route()?->getName() === 'statamic.cp.taxonomies.terms.create';
-    }
-
-    public static function isTermEditRoute(): bool
-    {
-        return request()->route()?->getName() === 'statamic.cp.taxonomies.terms.edit';
     }
 
     /**
@@ -55,13 +41,6 @@ class Helpers
      */
     public static function isCustomRoute(): bool
     {
-        $allowedControllerActions = collect([
-            'Aerni\AdvancedSeo\Http\Controllers\Web\SocialImagesController@show',
-            'Statamic\Http\Controllers\FrontendController@index',
-        ]);
-
-        $controllerAction = request()->route()?->getAction('controller');
-
-        return $allowedControllerActions->doesntContain($controllerAction);
+        return ! in_array(request()->route()?->getName(), ['statamic.site', 'social_images.show']);
     }
 }

--- a/src/Support/Helpers.php
+++ b/src/Support/Helpers.php
@@ -2,6 +2,7 @@
 
 namespace Aerni\AdvancedSeo\Support;
 
+use Statamic\Statamic;
 use Illuminate\Support\Str;
 
 class Helpers
@@ -13,14 +14,39 @@ class Helpers
         return \WhiteCube\Lingua\Service::create($parsed)->toW3C();
     }
 
+    public static function isActionCpRoute(): bool
+    {
+        return Statamic::isCpRoute() && Str::contains(request()->path(), 'actions');
+    }
+
     public static function isAddonCpRoute(): bool
     {
-        return Str::containsAll(request()->path(), [config('statamic.cp.route', 'cp'), 'advanced-seo']);
+        return Statamic::isCpRoute() && Str::contains(request()->path(), 'advanced-seo');
     }
 
     public static function isBlueprintCpRoute(): bool
     {
-        return Str::containsAll(request()->path(), [config('statamic.cp.route', 'cp'), 'blueprints']);
+        return Statamic::isCpRoute() && Str::contains(request()->path(), 'blueprints');
+    }
+
+    public static function isEntryCreateRoute(): bool
+    {
+        return request()->route()?->getName() === 'statamic.cp.collections.entries.create';
+    }
+
+    public static function isEntryEditRoute(): bool
+    {
+        return request()->route()?->getName() === 'statamic.cp.collections.entries.edit';
+    }
+
+    public static function isTermCreateRoute(): bool
+    {
+        return request()->route()?->getName() === 'statamic.cp.taxonomies.terms.create';
+    }
+
+    public static function isTermEditRoute(): bool
+    {
+        return request()->route()?->getName() === 'statamic.cp.taxonomies.terms.edit';
     }
 
     /**


### PR DESCRIPTION
This PR refactors some of the logic that determines the conditions under which a blueprint should be extended and aims to make it easier to add other conditions in the future. It also covers more scenarios to correctly evaluate the locale for the `DefaultsData` object.

We are waiting on feedback on PR https://github.com/statamic/cms/pull/10353 before merging this.