### PR TITLE
Fix error when `seo_generate_social_images` field is missing

### DIFF
--- a/src/Actions/ShouldGenerateSocialImages.php
+++ b/src/Actions/ShouldGenerateSocialImages.php
@@ -27,6 +27,6 @@ class ShouldGenerateSocialImages
         }
 
         // Only generate if the social images generator is turned on.
-        return $entry->seo_generate_social_images;
+        return $entry->seo_generate_social_images ?? false;
     }
 }


### PR DESCRIPTION
The `seo_generate_social_images` is added using a blueprint listener. However, I ran into a scenario, where this blueprint field is missing. So we need to return a default value, as the action shouldn't return null.