### PR TITLE
Improve handling of `hreflang` and `canonical`

### DIFF
--- a/lang/en/fields.php
+++ b/lang/en/fields.php
@@ -140,8 +140,8 @@ return [
 
     'seo_canonical_custom' => [
         'display' => 'URL',
-        'instructions' => 'A fully qualified URL starting with https://.',
-        'default_instructions' => 'A fully qualified URL starting with https://.',
+        'instructions' => 'A fully qualified and [active URL](https://laravel.com/docs/11.x/validation#rule-active-url).',
+        'default_instructions' => 'A fully qualified and [active URL](https://laravel.com/docs/11.x/validation#rule-active-url).',
     ],
 
     'seo_section_indexing' => [

--- a/resources/fieldsets/main.yaml
+++ b/resources/fieldsets/main.yaml
@@ -9,9 +9,9 @@ fields:
   -
     import: 'advanced-seo::twitter'
   -
-    import: 'advanced-seo::canonical_url'
-  -
     import: 'advanced-seo::indexing'
+  -
+    import: 'advanced-seo::canonical_url'
   -
     import: 'advanced-seo::sitemap'
   -

--- a/src/Actions/Indexable.php
+++ b/src/Actions/Indexable.php
@@ -3,6 +3,7 @@
 namespace Aerni\AdvancedSeo\Actions;
 
 use Aerni\AdvancedSeo\Facades\Seo;
+use Aerni\AdvancedSeo\View\Concerns\EvaluatesIndexability;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Contracts\Taxonomies\Taxonomy;
 use Statamic\Contracts\Taxonomies\Term;
@@ -10,8 +11,14 @@ use Statamic\Facades\Blink;
 
 class Indexable
 {
+    use EvaluatesIndexability;
+
     public static function handle(Entry|Term|Taxonomy $model, ?string $locale = null): bool
     {
+        if (! (new self)->crawlingIsEnabled()) {
+            return false;
+        }
+
         $locale = $locale ?? $model->locale();
 
         return Blink::once("{$model->id()}::{$locale}", function () use ($model, $locale) {

--- a/src/Fields/ContentDefaultsFields.php
+++ b/src/Fields/ContentDefaultsFields.php
@@ -21,8 +21,8 @@ class ContentDefaultsFields extends BaseFields
             $this->socialImagesGenerator(),
             $this->openGraphImage(),
             $this->twitterImage(),
-            $this->canonicalUrl(),
             $this->indexing(),
+            $this->canonicalUrl(),
             $this->sitemap(),
             $this->jsonLd(),
         ];
@@ -283,6 +283,44 @@ class ContentDefaultsFields extends BaseFields
         ];
     }
 
+    protected function indexing(): array
+    {
+        return [
+            [
+                'handle' => 'seo_section_indexing',
+                'field' => [
+                    'type' => 'section',
+                    'display' => $this->trans('seo_section_indexing.display'),
+                    'instructions' => $this->trans('seo_section_indexing.default_instructions'),
+                ],
+            ],
+            [
+                'handle' => 'seo_noindex',
+                'field' => [
+                    'type' => 'toggle',
+                    'display' => $this->trans('seo_noindex.display'),
+                    'instructions' => $this->trans('seo_noindex.default_instructions'),
+                    'default' => Defaults::data('collections')->get('seo_noindex'),
+                    'listable' => 'hidden',
+                    'localizable' => true,
+                    'width' => 50,
+                ],
+            ],
+            [
+                'handle' => 'seo_nofollow',
+                'field' => [
+                    'type' => 'toggle',
+                    'display' => $this->trans('seo_nofollow.display'),
+                    'instructions' => $this->trans('seo_nofollow.default_instructions'),
+                    'default' => Defaults::data('collections')->get('seo_nofollow'),
+                    'listable' => 'hidden',
+                    'localizable' => true,
+                    'width' => 50,
+                ],
+            ],
+        ];
+    }
+
     protected function canonicalUrl(): array
     {
         return [
@@ -342,44 +380,6 @@ class ContentDefaultsFields extends BaseFields
                     'validate' => [
                         'required_if:seo_canonical_type,custom',
                     ],
-                ],
-            ],
-        ];
-    }
-
-    protected function indexing(): array
-    {
-        return [
-            [
-                'handle' => 'seo_section_indexing',
-                'field' => [
-                    'type' => 'section',
-                    'display' => $this->trans('seo_section_indexing.display'),
-                    'instructions' => $this->trans('seo_section_indexing.default_instructions'),
-                ],
-            ],
-            [
-                'handle' => 'seo_noindex',
-                'field' => [
-                    'type' => 'toggle',
-                    'display' => $this->trans('seo_noindex.display'),
-                    'instructions' => $this->trans('seo_noindex.default_instructions'),
-                    'default' => Defaults::data('collections')->get('seo_noindex'),
-                    'listable' => 'hidden',
-                    'localizable' => true,
-                    'width' => 50,
-                ],
-            ],
-            [
-                'handle' => 'seo_nofollow',
-                'field' => [
-                    'type' => 'toggle',
-                    'display' => $this->trans('seo_nofollow.display'),
-                    'instructions' => $this->trans('seo_nofollow.default_instructions'),
-                    'default' => Defaults::data('collections')->get('seo_nofollow'),
-                    'listable' => 'hidden',
-                    'localizable' => true,
-                    'width' => 50,
                 ],
             ],
         ];

--- a/src/Fields/OnPageSeoFields.php
+++ b/src/Fields/OnPageSeoFields.php
@@ -20,8 +20,8 @@ class OnPageSeoFields extends BaseFields
             $this->socialImagesGenerator(),
             $this->openGraphImage(),
             $this->twitterImage(),
-            $this->canonicalUrl(),
             $this->indexing(),
+            $this->canonicalUrl(),
             $this->sitemap(),
             $this->jsonLd(),
         ];
@@ -379,6 +379,50 @@ class OnPageSeoFields extends BaseFields
         ];
     }
 
+    protected function indexing(): array
+    {
+        return [
+            [
+                'handle' => 'seo_section_indexing',
+                'field' => [
+                    'type' => 'section',
+                    'display' => $this->trans('seo_section_indexing.display'),
+                    'instructions' => $this->trans('seo_section_indexing.instructions'),
+                ],
+            ],
+            [
+                'handle' => 'seo_noindex',
+                'field' => [
+                    'type' => 'seo_source',
+                    'display' => $this->trans('seo_noindex.display'),
+                    'instructions' => $this->trans('seo_noindex.instructions'),
+                    'default' => '@default',
+                    'localizable' => true,
+                    'classes' => 'toggle-fieldtype',
+                    'width' => 50,
+                    'field' => [
+                        'type' => 'toggle',
+                    ],
+                ],
+            ],
+            [
+                'handle' => 'seo_nofollow',
+                'field' => [
+                    'type' => 'seo_source',
+                    'display' => $this->trans('seo_nofollow.display'),
+                    'instructions' => $this->trans('seo_nofollow.instructions'),
+                    'default' => '@default',
+                    'localizable' => true,
+                    'classes' => 'toggle-fieldtype',
+                    'width' => 50,
+                    'field' => [
+                        'type' => 'toggle',
+                    ],
+                ],
+            ],
+        ];
+    }
+
     protected function canonicalUrl(): array
     {
         return [
@@ -459,50 +503,6 @@ class OnPageSeoFields extends BaseFields
                         'validate' => [
                             'required_if:seo_canonical_type,custom',
                         ],
-                    ],
-                ],
-            ],
-        ];
-    }
-
-    protected function indexing(): array
-    {
-        return [
-            [
-                'handle' => 'seo_section_indexing',
-                'field' => [
-                    'type' => 'section',
-                    'display' => $this->trans('seo_section_indexing.display'),
-                    'instructions' => $this->trans('seo_section_indexing.instructions'),
-                ],
-            ],
-            [
-                'handle' => 'seo_noindex',
-                'field' => [
-                    'type' => 'seo_source',
-                    'display' => $this->trans('seo_noindex.display'),
-                    'instructions' => $this->trans('seo_noindex.instructions'),
-                    'default' => '@default',
-                    'localizable' => true,
-                    'classes' => 'toggle-fieldtype',
-                    'width' => 50,
-                    'field' => [
-                        'type' => 'toggle',
-                    ],
-                ],
-            ],
-            [
-                'handle' => 'seo_nofollow',
-                'field' => [
-                    'type' => 'seo_source',
-                    'display' => $this->trans('seo_nofollow.display'),
-                    'instructions' => $this->trans('seo_nofollow.instructions'),
-                    'default' => '@default',
-                    'localizable' => true,
-                    'classes' => 'toggle-fieldtype',
-                    'width' => 50,
-                    'field' => [
-                        'type' => 'toggle',
                     ],
                 ],
             ],

--- a/src/Fields/OnPageSeoFields.php
+++ b/src/Fields/OnPageSeoFields.php
@@ -502,6 +502,7 @@ class OnPageSeoFields extends BaseFields
                         'input_type' => 'url',
                         'validate' => [
                             'required_if:seo_canonical_type,custom',
+                            'active_url',
                         ],
                     ],
                 ],

--- a/src/Fields/OnPageSeoFields.php
+++ b/src/Fields/OnPageSeoFields.php
@@ -388,6 +388,9 @@ class OnPageSeoFields extends BaseFields
                     'type' => 'section',
                     'display' => $this->trans('seo_section_canonical_url.display'),
                     'instructions' => $this->trans('seo_section_canonical_url.instructions'),
+                    'if' => [
+                        'seo_noindex.value' => 'false',
+                    ],
                 ],
             ],
             [
@@ -399,6 +402,9 @@ class OnPageSeoFields extends BaseFields
                     'default' => '@default',
                     'localizable' => true,
                     'classes' => 'button_group-fieldtype',
+                    'if' => [
+                        'seo_noindex.value' => 'false',
+                    ],
                     'field' => [
                         'type' => 'button_group',
                         'options' => [
@@ -419,6 +425,7 @@ class OnPageSeoFields extends BaseFields
                     'localizable' => true,
                     'classes' => 'relationship-fieldtype',
                     'if' => [
+                        'seo_noindex.value' => 'false',
                         'seo_canonical_type.value' => 'equals other',
                     ],
                     'field' => [
@@ -443,6 +450,7 @@ class OnPageSeoFields extends BaseFields
                     'classes' => 'text-fieldtype',
                     'antlers' => true,
                     'if' => [
+                        'seo_noindex.value' => 'false',
                         'seo_canonical_type.value' => 'equals custom',
                     ],
                     'field' => [

--- a/src/Sitemap/CollectionSitemapUrl.php
+++ b/src/Sitemap/CollectionSitemapUrl.php
@@ -19,6 +19,10 @@ class CollectionSitemapUrl extends BaseSitemapUrl
 
     public function alternates(): ?array
     {
+        if (! Site::multiEnabled()) {
+            return null;
+        }
+
         $entries = $this->entries();
 
         // We only want alternate URLs if there are at least two entries.

--- a/src/Sitemap/CollectionSitemapUrl.php
+++ b/src/Sitemap/CollectionSitemapUrl.php
@@ -4,7 +4,6 @@ namespace Aerni\AdvancedSeo\Sitemap;
 
 use Aerni\AdvancedSeo\Actions\Indexable;
 use Aerni\AdvancedSeo\Support\Helpers;
-use Illuminate\Support\Collection;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Facades\Site;
 

--- a/src/Sitemap/CollectionSitemapUrl.php
+++ b/src/Sitemap/CollectionSitemapUrl.php
@@ -23,22 +23,38 @@ class CollectionSitemapUrl extends BaseSitemapUrl
             return null;
         }
 
-        $entries = $this->entries();
-
-        // We only want alternate URLs if there are at least two entries.
-        if ($entries->count() <= 1) {
+        if (! Indexable::handle($this->entry)) {
             return null;
         }
 
-        return $entries->map(fn ($entry) => [
-            'hreflang' => Helpers::parseLocale(Site::get($entry->locale())->locale()),
-            'href' => $this->absoluteUrl($entry),
-        ])
-            ->put('x-default', [
-                'hreflang' => 'x-default',
-                'href' => $this->absoluteUrl($this->entry->origin() ?? $this->entry),
-            ])
-            ->toArray();
+        $sites = $this->entry->sites();
+
+        if ($sites->count() < 2) {
+            return null;
+        }
+
+        $hreflang = $sites
+            ->map(fn ($locale) => $this->entry->in($locale))
+            ->filter() // A model might not exist in a site. So we need to remove it to prevent calling methods on null
+            ->filter(Indexable::handle(...));
+
+        if ($hreflang->count() < 2) {
+            return null;
+        }
+
+        $hreflang->transform(fn ($model) => [
+            'href' => $this->absoluteUrl($model),
+            'hreflang' => Helpers::parseLocale($model->site()->locale()),
+        ]);
+
+        $origin = $this->entry->origin() ?? $this->entry;
+
+        $xDefault = Indexable::handle($origin) ? $origin : $this->entry;
+
+        return $hreflang->push([
+            'href' => $this->absoluteUrl($xDefault),
+            'hreflang' => 'x-default',
+        ])->values()->all();
     }
 
     public function lastmod(): string
@@ -68,14 +84,5 @@ class CollectionSitemapUrl extends BaseSitemapUrl
             'current' => true,
             default => false,
         };
-    }
-
-    protected function entries(): Collection
-    {
-        $root = $this->entry->root();
-        $descendants = $root->descendants();
-
-        return collect([$root->locale() => $root])->merge($descendants)
-            ->filter(fn ($entry) => Indexable::handle($entry));
     }
 }

--- a/src/Sitemap/CollectionTaxonomySitemapUrl.php
+++ b/src/Sitemap/CollectionTaxonomySitemapUrl.php
@@ -21,6 +21,10 @@ class CollectionTaxonomySitemapUrl extends BaseSitemapUrl
 
     public function alternates(): ?array
     {
+        if (! Site::multiEnabled()) {
+            return null;
+        }
+
         $taxonomies = $this->taxonomies();
 
         // We only want alternate URLs if there are at least two terms.

--- a/src/Sitemap/CollectionTermSitemapUrl.php
+++ b/src/Sitemap/CollectionTermSitemapUrl.php
@@ -2,11 +2,11 @@
 
 namespace Aerni\AdvancedSeo\Sitemap;
 
-use Statamic\Facades\Site;
-use Illuminate\Support\Collection;
-use Aerni\AdvancedSeo\Support\Helpers;
-use Statamic\Contracts\Taxonomies\Term;
 use Aerni\AdvancedSeo\Actions\Indexable;
+use Aerni\AdvancedSeo\Support\Helpers;
+use Illuminate\Support\Collection;
+use Statamic\Contracts\Taxonomies\Term;
+use Statamic\Facades\Site;
 
 class CollectionTermSitemapUrl extends BaseSitemapUrl
 {

--- a/src/Sitemap/CollectionTermSitemapUrl.php
+++ b/src/Sitemap/CollectionTermSitemapUrl.php
@@ -18,6 +18,10 @@ class CollectionTermSitemapUrl extends BaseSitemapUrl
 
     public function alternates(): ?array
     {
+        if (! Site::multiEnabled()) {
+            return null;
+        }
+
         $terms = $this->terms();
 
         // We only want alternate URLs if there are at least two terms.

--- a/src/Sitemap/TaxonomySitemapUrl.php
+++ b/src/Sitemap/TaxonomySitemapUrl.php
@@ -30,6 +30,10 @@ class TaxonomySitemapUrl extends BaseSitemapUrl
 
     public function alternates(): ?array
     {
+        if (! Site::multiEnabled()) {
+            return null;
+        }
+
         $taxonomies = $this->taxonomies();
 
         // We only want alternate URLs if there are at least two terms.

--- a/src/Sitemap/TermSitemapUrl.php
+++ b/src/Sitemap/TermSitemapUrl.php
@@ -18,6 +18,10 @@ class TermSitemapUrl extends BaseSitemapUrl
 
     public function alternates(): ?array
     {
+        if (! Site::multiEnabled()) {
+            return null;
+        }
+
         $terms = $this->terms();
 
         // We only want alternate URLs if there are at least two terms.

--- a/src/Sitemap/TermSitemapUrl.php
+++ b/src/Sitemap/TermSitemapUrl.php
@@ -2,11 +2,11 @@
 
 namespace Aerni\AdvancedSeo\Sitemap;
 
-use Statamic\Facades\Site;
-use Illuminate\Support\Collection;
-use Aerni\AdvancedSeo\Support\Helpers;
-use Statamic\Contracts\Taxonomies\Term;
 use Aerni\AdvancedSeo\Actions\Indexable;
+use Aerni\AdvancedSeo\Support\Helpers;
+use Illuminate\Support\Collection;
+use Statamic\Contracts\Taxonomies\Term;
+use Statamic\Facades\Site;
 
 class TermSitemapUrl extends BaseSitemapUrl
 {

--- a/src/View/Concerns/EvaluatesContextType.php
+++ b/src/View/Concerns/EvaluatesContextType.php
@@ -2,8 +2,8 @@
 
 namespace Aerni\AdvancedSeo\View\Concerns;
 
-use Statamic\Taxonomies\Taxonomy;
 use Statamic\Contracts\Entries\Collection;
+use Statamic\Taxonomies\Taxonomy;
 
 trait EvaluatesContextType
 {

--- a/src/View/Concerns/EvaluatesContextType.php
+++ b/src/View/Concerns/EvaluatesContextType.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Aerni\AdvancedSeo\View\Concerns;
+
+use Statamic\Taxonomies\Taxonomy;
+use Statamic\Taxonomies\LocalizedTerm;
+use Statamic\Contracts\Entries\Collection;
+
+trait EvaluatesContextType
+{
+    protected function contextIsEntryOrTerm(): bool
+    {
+        return $this->model->value('is_entry')
+            || ($this->model->value('is_term') && ! $this->contextIsCollectionTerm());
+    }
+
+    protected function contextIsTaxonomy(): bool
+    {
+        return $this->model->get('page') instanceof Taxonomy
+            && $this->model->get('page')->collection() === null;
+    }
+
+    protected function contextIsCollectionTaxonomy(): bool
+    {
+        return $this->model->get('page') instanceof Taxonomy
+            && $this->model->get('page')->collection() instanceof Collection;
+    }
+
+    protected function contextIsCollectionTerm(): bool
+    {
+        return $this->model->get('page') instanceof LocalizedTerm
+            && $this->model->get('page')->collection() instanceof Collection;
+    }
+}

--- a/src/View/Concerns/EvaluatesContextType.php
+++ b/src/View/Concerns/EvaluatesContextType.php
@@ -3,15 +3,13 @@
 namespace Aerni\AdvancedSeo\View\Concerns;
 
 use Statamic\Taxonomies\Taxonomy;
-use Statamic\Taxonomies\LocalizedTerm;
 use Statamic\Contracts\Entries\Collection;
 
 trait EvaluatesContextType
 {
     protected function contextIsEntryOrTerm(): bool
     {
-        return $this->model->value('is_entry')
-            || ($this->model->value('is_term') && ! $this->contextIsCollectionTerm());
+        return $this->model->value('is_entry') || $this->model->value('is_term');
     }
 
     protected function contextIsTaxonomy(): bool
@@ -23,12 +21,6 @@ trait EvaluatesContextType
     protected function contextIsCollectionTaxonomy(): bool
     {
         return $this->model->get('page') instanceof Taxonomy
-            && $this->model->get('page')->collection() instanceof Collection;
-    }
-
-    protected function contextIsCollectionTerm(): bool
-    {
-        return $this->model->get('page') instanceof LocalizedTerm
             && $this->model->get('page')->collection() instanceof Collection;
     }
 }

--- a/src/View/Concerns/EvaluatesIndexability.php
+++ b/src/View/Concerns/EvaluatesIndexability.php
@@ -2,10 +2,10 @@
 
 namespace Aerni\AdvancedSeo\View\Concerns;
 
-use Statamic\Tags\Context;
 use Aerni\AdvancedSeo\Facades\Seo;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Sites\Site;
+use Statamic\Tags\Context;
 use Statamic\Taxonomies\LocalizedTerm;
 
 trait EvaluatesIndexability

--- a/src/View/Concerns/EvaluatesIndexability.php
+++ b/src/View/Concerns/EvaluatesIndexability.php
@@ -2,13 +2,34 @@
 
 namespace Aerni\AdvancedSeo\View\Concerns;
 
+use Statamic\Tags\Context;
 use Aerni\AdvancedSeo\Facades\Seo;
 use Statamic\Contracts\Entries\Entry;
+use Statamic\Sites\Site;
 use Statamic\Taxonomies\LocalizedTerm;
 
 trait EvaluatesIndexability
 {
-    protected function isIndexable(Entry|LocalizedTerm $model): bool
+    protected function isIndexable(Context|Entry|LocalizedTerm|Site $model): bool
+    {
+        return match (true) {
+            $model instanceof Context => $this->isIndexableContext($model),
+            $model instanceof Entry => $this->isIndexableEntryOrTerm($model),
+            $model instanceof LocalizedTerm => $this->isIndexableEntryOrTerm($model),
+            $model instanceof Site => $this->isIndexableSite($model->handle()),
+        };
+    }
+
+    protected function isIndexableContext(Context $context): bool
+    {
+        $model = $this->contextIsEntryOrTerm()
+            ? $context->get('id')->augmentable()
+            : $context->get('site');
+
+        return $this->isIndexable($model);
+    }
+
+    protected function isIndexableEntryOrTerm(Entry|LocalizedTerm $model): bool
     {
         return $this->isIndexableSite($model->locale()) // If the site is not indexable, the model should not be indexed.
             && $model->published() // Unpublished models should not be indexed.

--- a/src/View/Concerns/EvaluatesIndexability.php
+++ b/src/View/Concerns/EvaluatesIndexability.php
@@ -18,16 +18,15 @@ trait EvaluatesIndexability
 
     protected function isIndexableSite(string $locale): bool
     {
-        // If crawling is disabled, the site should not be indexed.
-        if (! in_array(app()->environment(), config('advanced-seo.crawling.environments', []))) {
+        if (! $this->crawlingIsEnabled()) {
             return false;
         }
 
-        $siteNoindex = Seo::find('site', 'indexing')
-            ?->in($locale)
-            ?->noindex;
+        return ! Seo::find('site', 'indexing')?->in($locale)?->noindex;
+    }
 
-        // If noindex is enabled, the site is should not be indexed.
-        return ! $siteNoindex;
+    protected function crawlingIsEnabled(): bool
+    {
+        return in_array(app()->environment(), config('advanced-seo.crawling.environments', []));
     }
 }

--- a/src/View/Concerns/EvaluatesIndexability.php
+++ b/src/View/Concerns/EvaluatesIndexability.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Aerni\AdvancedSeo\View\Concerns;
+
+use Aerni\AdvancedSeo\Facades\Seo;
+use Statamic\Contracts\Entries\Entry;
+use Statamic\Taxonomies\LocalizedTerm;
+
+trait EvaluatesIndexability
+{
+    protected function isIndexable(Entry|LocalizedTerm $model): bool
+    {
+        return $this->isIndexableSite($model->locale()) // If the site is not indexable, the model should not be indexed.
+            && $model->published() // Unpublished models should not be indexed.
+            && $model->url() // Models without a route should not be indexed.
+            && ! $model->seo_noindex; // Models with noindex should not be indexed.
+    }
+
+    protected function isIndexableSite(string $locale): bool
+    {
+        // If crawling is disabled, the site should not be indexed.
+        if (! in_array(app()->environment(), config('advanced-seo.crawling.environments', []))) {
+            return false;
+        }
+
+        $siteNoindex = Seo::find('site', 'indexing')
+            ?->in($locale)
+            ?->noindex;
+
+        // If noindex is enabled, the site is should not be indexed.
+        return ! $siteNoindex;
+    }
+}

--- a/src/View/Concerns/HasAbsoluteUrl.php
+++ b/src/View/Concerns/HasAbsoluteUrl.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Aerni\AdvancedSeo\View\Concerns;
+
+use Statamic\Facades\URL;
+
+trait HasAbsoluteUrl
+{
+    protected function absoluteUrl(object $model): ?string
+    {
+        if (method_exists($this, 'baseUrl') && $this->baseUrl()) {
+            return URL::assemble($this->baseUrl(), $model->url());
+        }
+
+        return $model->absoluteUrl();
+    }
+}

--- a/src/View/Concerns/HasHreflang.php
+++ b/src/View/Concerns/HasHreflang.php
@@ -2,13 +2,12 @@
 
 namespace Aerni\AdvancedSeo\View\Concerns;
 
-use Statamic\Facades\URL;
-use Statamic\Facades\Site;
-use Statamic\Taxonomies\Taxonomy;
-use Statamic\Contracts\Entries\Entry;
 use Aerni\AdvancedSeo\Support\Helpers;
+use Statamic\Contracts\Entries\Entry;
+use Statamic\Facades\Site;
+use Statamic\Facades\URL;
 use Statamic\Taxonomies\LocalizedTerm;
-use Aerni\AdvancedSeo\View\Concerns\EvaluatesIndexability;
+use Statamic\Taxonomies\Taxonomy;
 
 trait HasHreflang
 {

--- a/src/View/Concerns/HasHreflang.php
+++ b/src/View/Concerns/HasHreflang.php
@@ -129,41 +129,6 @@ trait HasHreflang
         ])->values()->all();
     }
 
-    protected function collectionTermHreflang(LocalizedTerm $term): ?array
-    {
-        if (! $this->isIndexable($term)) {
-            return null;
-        }
-
-        $sites = $term->taxonomy()->sites();
-
-        if ($sites->count() < 2) {
-            return null;
-        }
-
-        $hreflang = $sites
-            ->map(fn ($locale) => $term->in($locale))
-            ->filter($this->isIndexable(...));
-
-        if ($hreflang->count() < 2) {
-            return null;
-        }
-
-        $hreflang->transform(fn ($term) => [
-            'url' => $term->absoluteUrl(),
-            'locale' => Helpers::parseLocale($term->site()->locale()),
-        ]);
-
-        $origin = $term->origin();
-
-        $xDefault = $this->isIndexable($origin) ? $origin : $term;
-
-        return $hreflang->push([
-            'url' => $xDefault->absoluteUrl(),
-            'locale' => 'x-default',
-        ])->values()->all();
-    }
-
     protected function collectionTaxonomyUrl(Taxonomy $taxonomy, string $site): string
     {
         $siteUrl = Site::get($site)->absoluteUrl();

--- a/src/View/Concerns/HasHreflang.php
+++ b/src/View/Concerns/HasHreflang.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Aerni\AdvancedSeo\View\Concerns;
+
+use Statamic\Facades\URL;
+use Statamic\Facades\Site;
+use Statamic\Taxonomies\Taxonomy;
+use Statamic\Contracts\Entries\Entry;
+use Aerni\AdvancedSeo\Support\Helpers;
+use Statamic\Taxonomies\LocalizedTerm;
+use Aerni\AdvancedSeo\View\Concerns\EvaluatesIndexability;
+
+trait HasHreflang
+{
+    use EvaluatesIndexability;
+    use HasAbsoluteUrl;
+
+    protected function entryAndTermHreflang(Entry|LocalizedTerm $model): ?array
+    {
+        if (! $this->isIndexable($model)) {
+            return null;
+        }
+
+        $sites = $model instanceof Entry
+            ? $model->sites()
+            : $model->taxonomy()->sites();
+
+        if ($sites->count() < 2) {
+            return null;
+        }
+
+        $hreflang = $sites
+            ->map(fn ($locale) => $model->in($locale))
+            ->filter() // A model might not exist in a site. So we need to remove it to prevent calling methods on null
+            ->filter($this->isIndexable(...));
+
+        if ($hreflang->count() < 2) {
+            return null;
+        }
+
+        $hreflang->transform(fn ($model) => [
+            'url' => $this->absoluteUrl($model),
+            'locale' => Helpers::parseLocale($model->site()->locale()),
+        ]);
+
+        $origin = $model->origin() ?? $model;
+
+        $xDefault = $this->isIndexable($origin) ? $origin : $model;
+
+        return $hreflang->push([
+            'url' => $this->absoluteUrl($xDefault),
+            'locale' => 'x-default',
+        ])->values()->all();
+    }
+
+    protected function taxonomyHreflang(Taxonomy $taxonomy): ?array
+    {
+        // Save initial site so that we can restore it later.
+        $initialSite = Site::current()->handle();
+
+        if (! $this->isIndexableSite($initialSite)) {
+            return null;
+        }
+
+        $sites = $taxonomy
+            ->sites()
+            ->filter($this->isIndexableSite(...));
+
+        if ($sites->count() < 2) {
+            return null;
+        }
+
+        $hreflang = $sites->map(function ($site) use ($taxonomy) {
+            // Set the site so we can get the localized absolute URLs of the taxonomy.
+            Site::setCurrent($site);
+
+            return [
+                'url' => $taxonomy->absoluteUrl(),
+                'locale' => Helpers::parseLocale(Site::current()->locale()),
+            ];
+        });
+
+        $originSite = $taxonomy->sites()->first();
+
+        $xDefaultSite = $sites->contains($originSite) ? $originSite : $initialSite;
+
+        // Set the site so we can get the localized absolute URL for the x-default.
+        Site::setCurrent($xDefaultSite);
+
+        $hreflang->push([
+            'url' => $taxonomy->absoluteUrl(),
+            'locale' => 'x-default',
+        ]);
+
+        // Reset the site to the site of the model.
+        Site::setCurrent($initialSite);
+
+        return $hreflang->values()->all();
+    }
+
+    protected function collectionTaxonomyHreflang(Taxonomy $taxonomy): ?array
+    {
+        $initialSite = Site::current()->handle();
+
+        if (! $this->isIndexableSite($initialSite)) {
+            return null;
+        }
+
+        $sites = $taxonomy
+            ->sites()
+            ->filter($this->isIndexableSite(...));
+
+        if ($sites->count() < 2) {
+            return null;
+        }
+
+        $hreflang = $sites->map(fn ($site) => [
+            'url' => $this->collectionTaxonomyUrl($taxonomy, $site),
+            'locale' => Helpers::parseLocale(Site::get($site)->locale()),
+        ]);
+
+        $originSite = $taxonomy->sites()->first();
+
+        $xDefaultSite = $sites->contains($originSite) ? $originSite : $initialSite;
+
+        return $hreflang->push([
+            'url' => $this->collectionTaxonomyUrl($taxonomy, $xDefaultSite),
+            'locale' => 'x-default',
+        ])->values()->all();
+    }
+
+    protected function collectionTermHreflang(LocalizedTerm $term): ?array
+    {
+        if (! $this->isIndexable($term)) {
+            return null;
+        }
+
+        $sites = $term->taxonomy()->sites();
+
+        if ($sites->count() < 2) {
+            return null;
+        }
+
+        $hreflang = $sites
+            ->map(fn ($locale) => $term->in($locale))
+            ->filter($this->isIndexable(...));
+
+        if ($hreflang->count() < 2) {
+            return null;
+        }
+
+        $hreflang->transform(fn ($term) => [
+            'url' => $term->absoluteUrl(),
+            'locale' => Helpers::parseLocale($term->site()->locale()),
+        ]);
+
+        $origin = $term->origin();
+
+        $xDefault = $this->isIndexable($origin) ? $origin : $term;
+
+        return $hreflang->push([
+            'url' => $xDefault->absoluteUrl(),
+            'locale' => 'x-default',
+        ])->values()->all();
+    }
+
+    protected function collectionTaxonomyUrl(Taxonomy $taxonomy, string $site): string
+    {
+        $siteUrl = Site::get($site)->absoluteUrl();
+        $taxonomyHandle = $taxonomy->handle();
+        $collectionHandle = $taxonomy->collection()->handle();
+
+        return URL::tidy("{$siteUrl}/{$collectionHandle}/{$taxonomyHandle}");
+    }
+}

--- a/src/View/GraphQlCascade.php
+++ b/src/View/GraphQlCascade.php
@@ -153,13 +153,13 @@ class GraphQlCascade extends BaseCascade
 
     public function hreflang(): ?array
     {
-        if (! Site::multiEnabled()) {
-            return null;
-        }
-
         $sites = $this->model instanceof Entry
             ? $this->model->sites()
             : $this->model->taxonomy()->sites();
+
+        if ($sites->count() < 2) {
+            return null;
+        }
 
         $hreflang = $sites
             ->map(fn ($locale) => $this->model->in($locale))

--- a/src/View/GraphQlCascade.php
+++ b/src/View/GraphQlCascade.php
@@ -160,7 +160,7 @@ class GraphQlCascade extends BaseCascade
             ? $this->model->origin() ?? $this->model
             : $this->model->inDefaultLocale();
 
-        $hreflang = $sites->map(fn ($locale) => $this->model->in($locale))
+        return $sites->map(fn ($locale) => $this->model->in($locale))
             ->filter() // A model might not exist in a site. So we need to remove it to prevent calling methods on null
             ->filter(fn ($model) => $model->published()) // Remove any unpublished entries/terms
             ->filter(fn ($model) => $model->url()) // Remove any entries/terms with no route
@@ -174,8 +174,6 @@ class GraphQlCascade extends BaseCascade
             ])
             ->values()
             ->all();
-
-        return $hreflang;
     }
 
     public function canonical(): ?string

--- a/src/View/GraphQlCascade.php
+++ b/src/View/GraphQlCascade.php
@@ -2,18 +2,19 @@
 
 namespace Aerni\AdvancedSeo\View;
 
-use Aerni\AdvancedSeo\Concerns\HasBaseUrl;
-use Aerni\AdvancedSeo\Data\HasComputedData;
-use Aerni\AdvancedSeo\Facades\SocialImage;
-use Aerni\AdvancedSeo\Support\Helpers;
-use Illuminate\Support\Collection;
-use Spatie\SchemaOrg\Schema;
-use Statamic\Contracts\Assets\Asset;
-use Statamic\Contracts\Entries\Entry;
-use Statamic\Contracts\Taxonomies\Term;
-use Statamic\Facades\Data;
 use Statamic\Facades\URL;
 use Statamic\Support\Str;
+use Statamic\Facades\Data;
+use Statamic\Facades\Site;
+use Spatie\SchemaOrg\Schema;
+use Illuminate\Support\Collection;
+use Statamic\Contracts\Assets\Asset;
+use Statamic\Contracts\Entries\Entry;
+use Aerni\AdvancedSeo\Support\Helpers;
+use Statamic\Contracts\Taxonomies\Term;
+use Aerni\AdvancedSeo\Concerns\HasBaseUrl;
+use Aerni\AdvancedSeo\Facades\SocialImage;
+use Aerni\AdvancedSeo\Data\HasComputedData;
 
 class GraphQlCascade extends BaseCascade
 {
@@ -152,6 +153,10 @@ class GraphQlCascade extends BaseCascade
 
     public function hreflang(): ?array
     {
+        if (! Site::multiEnabled()) {
+            return null;
+        }
+
         $sites = $this->model instanceof Entry
             ? $this->model->sites()
             : $this->model->taxonomy()->sites();

--- a/src/View/GraphQlCascade.php
+++ b/src/View/GraphQlCascade.php
@@ -2,22 +2,22 @@
 
 namespace Aerni\AdvancedSeo\View;
 
-use Statamic\Facades\URL;
-use Statamic\Support\Str;
-use Statamic\Facades\Data;
-use Statamic\Facades\Site;
-use Spatie\SchemaOrg\Schema;
+use Aerni\AdvancedSeo\Concerns\HasBaseUrl;
+use Aerni\AdvancedSeo\Data\HasComputedData;
+use Aerni\AdvancedSeo\Facades\SocialImage;
+use Aerni\AdvancedSeo\Support\Helpers;
+use Aerni\AdvancedSeo\View\Concerns\EvaluatesIndexability;
+use Aerni\AdvancedSeo\View\Concerns\HasAbsoluteUrl;
+use Aerni\AdvancedSeo\View\Concerns\HasHreflang;
 use Illuminate\Support\Collection;
+use Spatie\SchemaOrg\Schema;
 use Statamic\Contracts\Assets\Asset;
 use Statamic\Contracts\Entries\Entry;
-use Aerni\AdvancedSeo\Support\Helpers;
 use Statamic\Contracts\Taxonomies\Term;
-use Aerni\AdvancedSeo\Concerns\HasBaseUrl;
-use Aerni\AdvancedSeo\Facades\SocialImage;
-use Aerni\AdvancedSeo\Data\HasComputedData;
-use Aerni\AdvancedSeo\View\Concerns\HasHreflang;
-use Aerni\AdvancedSeo\View\Concerns\HasAbsoluteUrl;
-use Aerni\AdvancedSeo\View\Concerns\EvaluatesIndexability;
+use Statamic\Facades\Data;
+use Statamic\Facades\Site;
+use Statamic\Facades\URL;
+use Statamic\Support\Str;
 
 class GraphQlCascade extends BaseCascade
 {

--- a/src/View/GraphQlCascade.php
+++ b/src/View/GraphQlCascade.php
@@ -2,24 +2,26 @@
 
 namespace Aerni\AdvancedSeo\View;
 
-use Aerni\AdvancedSeo\Concerns\HasBaseUrl;
-use Aerni\AdvancedSeo\Data\HasComputedData;
-use Aerni\AdvancedSeo\Facades\SocialImage;
-use Aerni\AdvancedSeo\Support\Helpers;
-use Aerni\AdvancedSeo\View\Concerns\HasAbsoluteUrl;
-use Aerni\AdvancedSeo\View\Concerns\HasHreflang;
-use Illuminate\Support\Collection;
-use Spatie\SchemaOrg\Schema;
-use Statamic\Contracts\Assets\Asset;
-use Statamic\Contracts\Entries\Entry;
-use Statamic\Contracts\Taxonomies\Term;
-use Statamic\Facades\Data;
-use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Support\Str;
+use Statamic\Facades\Data;
+use Statamic\Facades\Site;
+use Spatie\SchemaOrg\Schema;
+use Illuminate\Support\Collection;
+use Statamic\Contracts\Assets\Asset;
+use Statamic\Contracts\Entries\Entry;
+use Aerni\AdvancedSeo\Support\Helpers;
+use Statamic\Contracts\Taxonomies\Term;
+use Aerni\AdvancedSeo\Concerns\HasBaseUrl;
+use Aerni\AdvancedSeo\Facades\SocialImage;
+use Aerni\AdvancedSeo\Data\HasComputedData;
+use Aerni\AdvancedSeo\View\Concerns\HasHreflang;
+use Aerni\AdvancedSeo\View\Concerns\HasAbsoluteUrl;
+use Aerni\AdvancedSeo\View\Concerns\EvaluatesIndexability;
 
 class GraphQlCascade extends BaseCascade
 {
+    use EvaluatesIndexability;
     use HasAbsoluteUrl;
     use HasBaseUrl;
     use HasComputedData;
@@ -167,6 +169,10 @@ class GraphQlCascade extends BaseCascade
 
     public function canonical(): ?string
     {
+        if (! $this->isIndexable($this->model)) {
+            return null;
+        }
+
         $type = $this->get('canonical_type');
 
         if ($type == 'other' && $this->has('canonical_entry')) {

--- a/src/View/GraphQlCascade.php
+++ b/src/View/GraphQlCascade.php
@@ -2,19 +2,19 @@
 
 namespace Aerni\AdvancedSeo\View;
 
-use Statamic\Facades\URL;
-use Statamic\Support\Str;
-use Statamic\Facades\Data;
-use Statamic\Facades\Site;
-use Spatie\SchemaOrg\Schema;
+use Aerni\AdvancedSeo\Concerns\HasBaseUrl;
+use Aerni\AdvancedSeo\Data\HasComputedData;
+use Aerni\AdvancedSeo\Facades\SocialImage;
+use Aerni\AdvancedSeo\Support\Helpers;
 use Illuminate\Support\Collection;
+use Spatie\SchemaOrg\Schema;
 use Statamic\Contracts\Assets\Asset;
 use Statamic\Contracts\Entries\Entry;
-use Aerni\AdvancedSeo\Support\Helpers;
 use Statamic\Contracts\Taxonomies\Term;
-use Aerni\AdvancedSeo\Concerns\HasBaseUrl;
-use Aerni\AdvancedSeo\Facades\SocialImage;
-use Aerni\AdvancedSeo\Data\HasComputedData;
+use Statamic\Facades\Data;
+use Statamic\Facades\Site;
+use Statamic\Facades\URL;
+use Statamic\Support\Str;
 
 class GraphQlCascade extends BaseCascade
 {
@@ -184,8 +184,8 @@ class GraphQlCascade extends BaseCascade
             'url' => $origin->published() ? $this->absoluteUrl($origin) : $this->absoluteUrl($this->model),
             'locale' => 'x-default',
         ])
-        ->values()
-        ->all();
+            ->values()
+            ->all();
     }
 
     public function canonical(): ?string

--- a/src/View/ViewCascade.php
+++ b/src/View/ViewCascade.php
@@ -2,22 +2,22 @@
 
 namespace Aerni\AdvancedSeo\View;
 
-use Statamic\Facades\URL;
-use Statamic\Support\Str;
-use Statamic\Facades\Data;
-use Statamic\Facades\Site;
-use Statamic\Tags\Context;
-use Statamic\Facades\Blink;
-use Spatie\SchemaOrg\Schema;
-use Illuminate\Support\Collection;
-use Statamic\Contracts\Assets\Asset;
+use Aerni\AdvancedSeo\Data\HasComputedData;
+use Aerni\AdvancedSeo\Facades\SocialImage;
 use Aerni\AdvancedSeo\Models\Defaults;
 use Aerni\AdvancedSeo\Support\Helpers;
-use Aerni\AdvancedSeo\Facades\SocialImage;
-use Aerni\AdvancedSeo\Data\HasComputedData;
 use Aerni\AdvancedSeo\View\Concerns\EvaluatesContextType;
 use Aerni\AdvancedSeo\View\Concerns\HasHreflang;
+use Illuminate\Support\Collection;
+use Spatie\SchemaOrg\Schema;
+use Statamic\Contracts\Assets\Asset;
+use Statamic\Facades\Blink;
+use Statamic\Facades\Data;
+use Statamic\Facades\Site;
+use Statamic\Facades\URL;
 use Statamic\Stache\Query\TermQueryBuilder;
+use Statamic\Support\Str;
+use Statamic\Tags\Context;
 
 class ViewCascade extends BaseCascade
 {

--- a/src/View/ViewCascade.php
+++ b/src/View/ViewCascade.php
@@ -7,6 +7,7 @@ use Aerni\AdvancedSeo\Facades\SocialImage;
 use Aerni\AdvancedSeo\Models\Defaults;
 use Aerni\AdvancedSeo\Support\Helpers;
 use Aerni\AdvancedSeo\View\Concerns\EvaluatesContextType;
+use Aerni\AdvancedSeo\View\Concerns\EvaluatesIndexability;
 use Aerni\AdvancedSeo\View\Concerns\HasHreflang;
 use Illuminate\Support\Collection;
 use Spatie\SchemaOrg\Schema;
@@ -22,6 +23,7 @@ use Statamic\Tags\Context;
 class ViewCascade extends BaseCascade
 {
     use EvaluatesContextType;
+    use EvaluatesIndexability;
     use HasComputedData;
     use HasHreflang;
 
@@ -198,6 +200,10 @@ class ViewCascade extends BaseCascade
 
     public function canonical(): ?string
     {
+        if (! $this->isIndexable($this->model)) {
+            return null;
+        }
+
         $type = $this->get('canonical_type');
 
         if ($type == 'other' && $this->get('canonical_entry')) {

--- a/src/View/ViewCascade.php
+++ b/src/View/ViewCascade.php
@@ -2,26 +2,28 @@
 
 namespace Aerni\AdvancedSeo\View;
 
-use Aerni\AdvancedSeo\Data\HasComputedData;
-use Aerni\AdvancedSeo\Facades\SocialImage;
-use Aerni\AdvancedSeo\Models\Defaults;
-use Aerni\AdvancedSeo\Support\Helpers;
-use Illuminate\Support\Collection;
-use Spatie\SchemaOrg\Schema;
-use Statamic\Contracts\Assets\Asset;
-use Statamic\Contracts\Entries\Entry;
-use Statamic\Contracts\Taxonomies\Taxonomy;
-use Statamic\Facades\Blink;
+use Statamic\Facades\URL;
+use Statamic\Support\Str;
 use Statamic\Facades\Data;
 use Statamic\Facades\Site;
-use Statamic\Facades\URL;
-use Statamic\Stache\Query\TermQueryBuilder;
-use Statamic\Support\Str;
 use Statamic\Tags\Context;
+use Statamic\Facades\Blink;
+use Spatie\SchemaOrg\Schema;
+use Illuminate\Support\Collection;
+use Statamic\Contracts\Assets\Asset;
+use Aerni\AdvancedSeo\Models\Defaults;
+use Aerni\AdvancedSeo\Support\Helpers;
+use Aerni\AdvancedSeo\Facades\SocialImage;
+use Aerni\AdvancedSeo\Data\HasComputedData;
+use Aerni\AdvancedSeo\View\Concerns\EvaluatesContextType;
+use Aerni\AdvancedSeo\View\Concerns\HasHreflang;
+use Statamic\Stache\Query\TermQueryBuilder;
 
 class ViewCascade extends BaseCascade
 {
+    use EvaluatesContextType;
     use HasComputedData;
+    use HasHreflang;
 
     public function __construct(Context $model)
     {
@@ -187,137 +189,12 @@ class ViewCascade extends BaseCascade
         }
 
         return match (true) {
-            ($this->model->has('segment_2') && $this->model->get('terms') instanceof TermQueryBuilder) => $this->collectionTaxonomyHreflang(),
-            ($this->model->has('segment_3') && $this->model->value('is_term') === true) => $this->collectionTermHreflang(),
-            ($this->model->has('segment_1') && $this->model->get('terms') instanceof TermQueryBuilder) => $this->taxonomyHreflang(),
-            default => $this->entryAndTermHreflang(),
+            ($this->contextIsEntryOrTerm()) => $this->entryAndTermHreflang($this->model->get('id')->resolve()->augmentable()), // TODO: Remove resolve() once https://github.com/statamic/cms/pull/10417 is merged.
+            ($this->contextIsTaxonomy()) => $this->taxonomyHreflang($this->model->get('page')),
+            ($this->contextIsCollectionTaxonomy()) => $this->collectionTaxonomyHreflang($this->model->get('page')),
+            ($this->contextIsCollectionTerm()) => $this->collectionTermHreflang($this->model->get('page')),
+            default => null
         };
-    }
-
-    protected function entryAndTermHreflang(): ?array
-    {
-        $data = Data::find($this->model->value('id'));
-
-        if (! $data) {
-            return null;
-        }
-
-        $sites = $data instanceof Entry
-            ? $data->sites()
-            : $data->taxonomy()->sites();
-
-        if ($sites->count() < 2) {
-            return null;
-        }
-
-        $hreflang = $sites
-            ->map(fn ($locale) => $data->in($locale))
-            ->filter() // A model might not exist in a site. So we need to remove it to prevent calling methods on null
-            ->filter(fn ($model) => $model->published()) // Remove any unpublished entries/terms
-            ->filter(fn ($model) => $model->url()); // Remove any entries/terms with no route
-
-        if ($hreflang->count() < 2) {
-            return null;
-        }
-
-        $hreflang->transform(fn ($model) => [
-            'url' => $model->absoluteUrl(),
-            'locale' => Helpers::parseLocale($model->site()->locale()),
-        ]);
-
-        $origin = $data instanceof Entry
-            ? $data->origin() ?? $data
-            : $data->inDefaultLocale();
-
-        return $hreflang->push([
-            'url' => $origin->published() ? $origin->absoluteUrl() : $data->absoluteUrl(),
-            'locale' => 'x-default',
-        ])
-            ->values()
-            ->all();
-    }
-
-    protected function taxonomyHreflang(): ?array
-    {
-        $taxonomy = $this->model->get('page');
-
-        if ($taxonomy->sites()->count() < 2) {
-            return null;
-        }
-
-        $initialSite = Site::current()->handle();
-
-        $hreflang = $taxonomy->sites()->map(function ($locale) use ($taxonomy) {
-            // Set the current site so we can get the localized absolute URLs of the taxonomy.
-            Site::setCurrent($locale);
-
-            return [
-                'url' => $taxonomy->absoluteUrl(),
-                'locale' => Helpers::parseLocale(Site::current()->locale()),
-            ];
-        });
-
-        // We need to set the site to the taxonomy origin site so that we can get to correct URL of the taxonomy.
-        Site::setCurrent($taxonomy->sites()->first());
-
-        $hreflang->push([
-            'url' => $taxonomy->absoluteUrl(),
-            'locale' => 'x-default',
-        ]);
-
-        // Reset the site to the original.
-        Site::setCurrent($initialSite);
-
-        return $hreflang->all();
-    }
-
-    protected function collectionTaxonomyHreflang(): ?array
-    {
-        $taxonomy = $this->model->get('page');
-
-        if ($taxonomy->sites()->count() < 2) {
-            return null;
-        }
-
-        return $taxonomy->sites()
-            ->map(fn ($site) => [
-                'url' => $this->getCollectionTaxonomyUrl($taxonomy, $site),
-                'locale' => Helpers::parseLocale(Site::get($site)->locale()),
-            ])
-            ->push([
-                'url' => $this->getCollectionTaxonomyUrl($taxonomy, $taxonomy->sites()->first()),
-                'locale' => 'x-default',
-            ])
-            ->all();
-    }
-
-    protected function collectionTermHreflang(): ?array
-    {
-        $localizedTerm = $this->model->get('page');
-
-        if ($localizedTerm->taxonomy()->sites()->count() < 2) {
-            return null;
-        }
-
-        return $localizedTerm->taxonomy()->sites()
-            ->map(fn ($locale) => [
-                'url' => $localizedTerm->in($locale)->absoluteUrl(),
-                'locale' => Helpers::parseLocale(Site::get($locale)->locale()),
-            ])
-            ->push([
-                'url' => $localizedTerm->origin()->absoluteUrl(),
-                'locale' => 'x-default',
-            ])
-            ->all();
-    }
-
-    protected function getCollectionTaxonomyUrl(Taxonomy $taxonomy, string $site): string
-    {
-        $siteUrl = Site::get($site)->absoluteUrl();
-        $taxonomyHandle = $taxonomy->handle();
-        $collectionHandle = $taxonomy->collection()->handle();
-
-        return URL::tidy("{$siteUrl}/{$collectionHandle}/{$taxonomyHandle}");
     }
 
     public function canonical(): ?string

--- a/src/View/ViewCascade.php
+++ b/src/View/ViewCascade.php
@@ -192,7 +192,6 @@ class ViewCascade extends BaseCascade
             ($this->contextIsEntryOrTerm()) => $this->entryAndTermHreflang($this->model->get('id')->resolve()->augmentable()), // TODO: Remove resolve() once https://github.com/statamic/cms/pull/10417 is merged.
             ($this->contextIsTaxonomy()) => $this->taxonomyHreflang($this->model->get('page')),
             ($this->contextIsCollectionTaxonomy()) => $this->collectionTaxonomyHreflang($this->model->get('page')),
-            ($this->contextIsCollectionTerm()) => $this->collectionTermHreflang($this->model->get('page')),
             default => null
         };
     }

--- a/src/View/ViewCascade.php
+++ b/src/View/ViewCascade.php
@@ -208,7 +208,7 @@ class ViewCascade extends BaseCascade
 
         if ($sites->count() < 2) {
             return null;
-        };
+        }
 
         $hreflang = $sites
             ->map(fn ($locale) => $data->in($locale))
@@ -233,8 +233,8 @@ class ViewCascade extends BaseCascade
             'url' => $origin->published() ? $origin->absoluteUrl() : $data->absoluteUrl(),
             'locale' => 'x-default',
         ])
-        ->values()
-        ->all();
+            ->values()
+            ->all();
     }
 
     protected function taxonomyHreflang(): ?array
@@ -243,7 +243,7 @@ class ViewCascade extends BaseCascade
 
         if ($taxonomy->sites()->count() < 2) {
             return null;
-        };
+        }
 
         $initialSite = Site::current()->handle();
 
@@ -277,7 +277,7 @@ class ViewCascade extends BaseCascade
 
         if ($taxonomy->sites()->count() < 2) {
             return null;
-        };
+        }
 
         return $taxonomy->sites()
             ->map(fn ($site) => [
@@ -297,7 +297,7 @@ class ViewCascade extends BaseCascade
 
         if ($localizedTerm->taxonomy()->sites()->count() < 2) {
             return null;
-        };
+        }
 
         return $localizedTerm->taxonomy()->sites()
             ->map(fn ($locale) => [

--- a/src/View/ViewCascade.php
+++ b/src/View/ViewCascade.php
@@ -206,6 +206,10 @@ class ViewCascade extends BaseCascade
             ? $data->sites()
             : $data->taxonomy()->sites();
 
+        if ($sites->count() < 2) {
+            return null;
+        };
+
         $hreflang = $sites
             ->map(fn ($locale) => $data->in($locale))
             ->filter() // A model might not exist in a site. So we need to remove it to prevent calling methods on null

--- a/src/View/ViewCascade.php
+++ b/src/View/ViewCascade.php
@@ -231,6 +231,10 @@ class ViewCascade extends BaseCascade
 
     public function prevUrl(): ?string
     {
+        if (! $this->isIndexable($this->model)) {
+            return null;
+        }
+
         if (! $paginator = Blink::get('tag-paginator')) {
             return null;
         }
@@ -251,6 +255,10 @@ class ViewCascade extends BaseCascade
 
     public function nextUrl(): ?string
     {
+        if (! $this->isIndexable($this->model)) {
+            return null;
+        }
+
         if (! $paginator = Blink::get('tag-paginator')) {
             return null;
         }

--- a/src/View/ViewCascade.php
+++ b/src/View/ViewCascade.php
@@ -182,6 +182,10 @@ class ViewCascade extends BaseCascade
 
     public function hreflang(): ?array
     {
+        if (! Site::multiEnabled()) {
+            return null;
+        }
+
         return match (true) {
             ($this->model->has('segment_2') && $this->model->get('terms') instanceof TermQueryBuilder) => $this->collectionTaxonomyHreflang(),
             ($this->model->has('segment_3') && $this->model->value('is_term') === true) => $this->collectionTermHreflang(),


### PR DESCRIPTION
This PR adds some improvements around the handling and generation of the `hreflang` and `canonical` tags.

- If multi-site is disabled, the `hreflang` won't be generated.
- If an entry/term/taxonomy only has one localization, the `hreflang` won't be generated.
- If a page is not indexable `hreflang`, `canonical`, `prev`, and `next` won't be generated.
- Set the correct `x-default` in sitemaps when the origin of an entry/term isn't indexable.
- If `canonical` points to another URL, the `hreflang` won't be generated.
- Hide the `Canonical URL` section in the `SEO` tab if `noindex` is enabled.
- Validate that the `seo_canonical_custom` is an [active_url](https://laravel.com/docs/11.x/validation#rule-active-url).