### PR TITLE
Fix wrong variable type check

### DIFF
--- a/src/Fieldtypes/SourceFieldtype.php
+++ b/src/Fieldtypes/SourceFieldtype.php
@@ -84,7 +84,7 @@ class SourceFieldtype extends Fieldtype
         if ($data === '@default') {
             $value = $this->sourceFieldtype()->augment($this->defaultValueFromCascade());
 
-            return is_string($data) && Str::contains($value, '@field')
+            return is_string($value) && Str::contains($value, '@field')
                 ? $this->sourceFieldtype()->augment($this->parseFieldValues($value))
                 : $value;
         }


### PR DESCRIPTION
This PR fixes an issue where we are checking the `$data` to be a string instead of the `$value`.