### PR TITLE
Fix GraphQL exception caused by canonical entry

### DIFF
--- a/src/Actions/GetSiteDefaults.php
+++ b/src/Actions/GetSiteDefaults.php
@@ -2,13 +2,13 @@
 
 namespace Aerni\AdvancedSeo\Actions;
 
+use Aerni\AdvancedSeo\Data\DefaultsData;
+use Aerni\AdvancedSeo\Models\Defaults;
+use Illuminate\Support\Collection;
+use Statamic\Facades\Blink;
 use Statamic\Facades\Site;
 use Statamic\Fields\Value;
 use Statamic\Tags\Context;
-use Statamic\Facades\Blink;
-use Illuminate\Support\Collection;
-use Aerni\AdvancedSeo\Models\Defaults;
-use Aerni\AdvancedSeo\Data\DefaultsData;
 
 class GetSiteDefaults
 {

--- a/src/Actions/GetSiteDefaults.php
+++ b/src/Actions/GetSiteDefaults.php
@@ -2,12 +2,13 @@
 
 namespace Aerni\AdvancedSeo\Actions;
 
-use Aerni\AdvancedSeo\Data\DefaultsData;
-use Aerni\AdvancedSeo\Models\Defaults;
-use Illuminate\Support\Collection;
-use Statamic\Facades\Blink;
 use Statamic\Facades\Site;
 use Statamic\Fields\Value;
+use Statamic\Tags\Context;
+use Statamic\Facades\Blink;
+use Illuminate\Support\Collection;
+use Aerni\AdvancedSeo\Models\Defaults;
+use Aerni\AdvancedSeo\Data\DefaultsData;
 
 class GetSiteDefaults
 {
@@ -17,10 +18,6 @@ class GetSiteDefaults
             return collect();
         }
 
-        /**
-         * TODO: Instead of using the overriding code at the bottom, we might be able to refactor this to something similar to the GetPageData action.
-         * Instead of augmenting all the default values upfront, we could get the blueprint of each site default and then add the values to each blueprint field.
-         */
         return Blink::once("advanced-seo::site::{$locale}", function () use ($locale, $data) {
             $siteDefaults = Defaults::enabledInType('site')
                 ->flatMap(fn ($model) => GetAugmentedDefaults::handle(
@@ -33,19 +30,33 @@ class GetSiteDefaults
                 ));
 
             /**
-             * Allow overriding site defaults by matching key in the data.
-             * This is useful if you want to override the site default when working with custom views.
-             * We need to create a new value object because we can't simply change the `value` in the existing object.
+             * TODO: Instead of merging the overrides, we might be able to refactor this to something similar to the GetPageData action.
+             * Instead of augmenting all the default values upfront, we could get the blueprint of each site default and then add the values to each blueprint field.
              */
-            $overrides = $siteDefaults->intersectByKeys($data)
-                ->map(fn ($originalValue, $key) => new Value(
-                    value: ($value = $data->get($key)) instanceof Value ? $value->raw() : $value,
-                    handle: $originalValue->handle(),
-                    fieldtype: $originalValue->fieldtype(),
-                    augmentable: $originalValue->augmentable()
-                ));
+            if ($data instanceof Context) {
+                return self::mergeViewOverrides($siteDefaults, $data);
+            }
 
-            return $siteDefaults->merge($overrides);
+            return $siteDefaults;
         });
+    }
+
+    /**
+     * Allow overriding site defaults by matching key in the data.
+     * This is useful if you want to override the site default when working with custom views.
+     * We need to create a new value object because we can't simply change the `value` in the existing object.
+     */
+    protected static function mergeViewOverrides(Collection $siteDefaults, Collection $overrides): Collection
+    {
+        $overrides = $siteDefaults
+            ->intersectByKeys($overrides)
+            ->map(fn ($originalValue, $key) => new Value(
+                value: ($value = $overrides->get($key)) instanceof Value ? $value->raw() : $value,
+                handle: $originalValue->handle(),
+                fieldtype: $originalValue->fieldtype(),
+                augmentable: $originalValue->augmentable()
+            ));
+
+        return $siteDefaults->merge($overrides);
     }
 }


### PR DESCRIPTION
This PR fixes an exception that would be triggered when querying any computed value with GraphQL. The exception would always happen, when the `seo_canonical_entry` was set to an entry. I was able to track it down to the `GetSiteDefaults` action and the merging of overrides. I wasn't able to figure out what exactly was causing the issue. But we can simply implement a condition to only merge the overrides when the data is a `Context`. Which is only the case when we are dealing with the `ViewCascade`.