### PR TITLE
Fixing the type()-finder-function

### DIFF
--- a/src/Http/Controllers/Cp/SeoDefaultsController.php
+++ b/src/Http/Controllers/Cp/SeoDefaultsController.php
@@ -201,6 +201,9 @@ class SeoDefaultsController extends CpController
 
     protected function type(): string
     {
-        return request()->segments()[2];
+        $segments = request()->segments();
+        $key = array_search('advanced-seo', $segments) + 1;
+
+        return $segments[$key];
     }
 }

--- a/src/Http/Controllers/Cp/SeoDefaultsController.php
+++ b/src/Http/Controllers/Cp/SeoDefaultsController.php
@@ -201,9 +201,6 @@ class SeoDefaultsController extends CpController
 
     protected function type(): string
     {
-        $segments = request()->segments();
-        $key = array_search('advanced-seo', $segments) + 1;
-
-        return $segments[$key];
+        return collect(request()->segments())->after('advanced-seo');
     }
 }


### PR DESCRIPTION
I am using Statamic as a Headless Backend for a Gatsby-Frontend.

Therefore the backend is directly within the domain's root rather then cp, which breaks the type-search.

I created a little workaround, that fixes that problem for all cases.

Thanks in advance.