### PR TITLE
Make type() method work with Laravel 10

### DIFF
--- a/src/Http/Controllers/Cp/SeoDefaultsController.php
+++ b/src/Http/Controllers/Cp/SeoDefaultsController.php
@@ -201,6 +201,9 @@ class SeoDefaultsController extends CpController
 
     protected function type(): string
     {
-        return collect(request()->segments())->after('advanced-seo');
+        $segments = request()->segments();
+        $key = array_search('advanced-seo', $segments) + 1;
+
+        return $segments[$key];
     }
 }


### PR DESCRIPTION
This PR closes https://github.com/aerni/statamic-advanced-seo/issues/172 and implements the original solution suggested in #168. As it turns out, the current solution doesn't work with Laravel 10.

Note: This can be reverted once we're dropping support for Laravel 10.