### PR TITLE
Fix Browsershot security vulnerability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.2",
         "laravel/framework": "^10.0 || ^11.0",
         "laravel/prompts": "^0.1.24",
-        "spatie/browsershot": "^4.0",
+        "spatie/browsershot": "^5.0.5",
         "spatie/image": "^3.4",
         "spatie/laravel-ray": "^1.32",
         "spatie/schema-org": "^3.14",

--- a/tests/Tags/AdvancedSeoTagsTest.php
+++ b/tests/Tags/AdvancedSeoTagsTest.php
@@ -11,7 +11,7 @@ class AdvancedSeoTagsTest extends TestCase
 
     protected $context = ['foo' => 'bar'];
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,7 +23,7 @@ class TestCase extends OrchestraTestCase
         }
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $uses = array_flip(class_uses_recursive(static::class));
 


### PR DESCRIPTION
This PR closes #176 and updates Browsershot to the latest version to close a severe security vulnerability.