### PR TITLE
Fix sitemap inclusion query when used with Eloquent driver

### DIFF
--- a/src/Sitemaps/BaseSitemap.php
+++ b/src/Sitemaps/BaseSitemap.php
@@ -17,7 +17,6 @@ use Illuminate\Support\Str;
 use Statamic\Contracts\Query\Builder;
 use Statamic\Facades\Addon;
 use Statamic\Facades\URL;
-use Statamic\Query\EloquentQueryBuilder;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 abstract class BaseSitemap implements Arrayable, Contract, Renderable, Responsable, SitemapFile
@@ -62,12 +61,9 @@ abstract class BaseSitemap implements Arrayable, Contract, Renderable, Responsab
 
     protected function includeInSitemapQuery(Builder $query): Builder
     {
-        // The Eloquent driver seems to require a different column name for the URL
-        $urlColumn = $query instanceof EloquentQueryBuilder ? 'uri' : 'url';
-
         return $query
             ->where('published', true)
-            ->whereNotNull($urlColumn);
+            ->whereNotNull('uri');
 
         /**
          * A reminder for my later self. We used to also include the following queries here:

--- a/src/Sitemaps/BaseSitemap.php
+++ b/src/Sitemaps/BaseSitemap.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Str;
 use Statamic\Contracts\Query\Builder;
 use Statamic\Facades\Addon;
 use Statamic\Facades\URL;
+use Statamic\Query\EloquentQueryBuilder;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 abstract class BaseSitemap implements Arrayable, Contract, Renderable, Responsable, SitemapFile
@@ -61,9 +62,12 @@ abstract class BaseSitemap implements Arrayable, Contract, Renderable, Responsab
 
     protected function includeInSitemapQuery(Builder $query): Builder
     {
+        // The Eloquent driver seems to require a different column name for the URL
+        $urlColumn = $query instanceof EloquentQueryBuilder ? 'uri' : 'url';
+
         return $query
             ->where('published', true)
-            ->whereNotNull('url');
+            ->whereNotNull($urlColumn);
 
         /**
          * A reminder for my later self. We used to also include the following queries here:


### PR DESCRIPTION
- The Eloquent driver seems to require `uri` as column name to check for the existence of a public route
- It might be that `uri` would work for both flat-file and Eloquent, but I don't have a quick way of testing that
- Closes #180 