### PR TITLE
Fix serialization exception

### DIFF
--- a/src/View/CascadeComposer.php
+++ b/src/View/CascadeComposer.php
@@ -11,7 +11,14 @@ class CascadeComposer
 {
     public function compose(View $view): void
     {
-        $context = new Context($view->getData());
+        /**
+         * This prevents a "Serialization of 'Closure' is not allowed" exception when using the {{ nocache }} tag.
+         * The issue is caused by closures in the config array. We don't need this value for the ViewCascade
+         * so we can safely remove it here. See: https://github.com/aerni/statamic-advanced-seo/issues/175
+         */
+        $values = collect($view->getData())->except('config');
+
+        $context = new Context($values);
 
         if (! $context->has('current_template')) {
             $context = $this->getContextFromCascade($context);


### PR DESCRIPTION
This PR closes #175 by removing the `config` array from the data that is used to construct the `ViewCascade`. The issue would happen when a closure was encountered in a config file such as Statamic's search filters.