### PR TITLE
Fix duplicate IDs Stache error

### DIFF
--- a/src/Data/SeoDefaultSet.php
+++ b/src/Data/SeoDefaultSet.php
@@ -30,14 +30,7 @@ class SeoDefaultSet implements Contract
 
     public function id(): string
     {
-        return $this->handle();
-
-        /**
-         * TODO: It would be nice to simply call $set->id in the ContentDefaultsController and SiteDefaultsController.
-         * But if we change the ID to consist of the type and handle, everything breaks.
-         * It looks like an issue with the Stache. Have to investigate this come more.
-         */
-        // return "{$this->type()}::{$this->handle()}";
+        return "{$this->type()}::{$this->handle()}";
     }
 
     public function handle($handle = null)

--- a/src/Http/Controllers/Cp/SeoDefaultsController.php
+++ b/src/Http/Controllers/Cp/SeoDefaultsController.php
@@ -76,9 +76,7 @@ class SeoDefaultsController extends CpController
             'actions' => [
                 'save' => $localization->updateUrl(),
             ],
-            // TODO: Make this work with $set->id()
-            // 'values' => array_merge($values, ['id' => $set->id()]),
-            'values' => array_merge($values, ['id' => "{$set->type()}::{$set->handle()}"]),
+            'values' => array_merge($values, ['id' => $set->id()]),
             'meta' => $meta,
             'blueprint' => $blueprint->toPublishArray(),
             'locale' => $localization->locale(),

--- a/src/Stache/SeoDefaultsRepository.php
+++ b/src/Stache/SeoDefaultsRepository.php
@@ -28,7 +28,7 @@ class SeoDefaultsRepository implements Contract
 
     public function find(string $type, string $handle): ?SeoDefaultSet
     {
-        return $this->store->store($type)->getItem($handle);
+        return $this->store->store($type)->getItem("{$type}::{$handle}");
     }
 
     public function findOrMake(string $type, string $handle): SeoDefaultSet


### PR DESCRIPTION
This PR ensures that each `SeoDefaultSet` has a unique ID and closes #187.