### PR TITLE
Throw sitemap exceptions inside of methods

### DIFF
--- a/src/Http/Controllers/Web/SitemapController.php
+++ b/src/Http/Controllers/Web/SitemapController.php
@@ -14,19 +14,19 @@ class SitemapController extends Controller
 {
     use EvaluatesIndexability;
 
-    public function __construct()
+    public function index(): SitemapIndex
     {
         throw_unless(config('advanced-seo.sitemap.enabled'), new NotFoundHttpException);
         throw_unless($this->crawlingIsEnabled(), new NotFoundHttpException);
-    }
 
-    public function index(): SitemapIndex
-    {
         return SitemapRepository::index();
     }
 
     public function show(string $id): Sitemap
     {
+        throw_unless(config('advanced-seo.sitemap.enabled'), new NotFoundHttpException);
+        throw_unless($this->crawlingIsEnabled(), new NotFoundHttpException);
+
         return throw_unless(SitemapRepository::find($id), NotFoundHttpException::class);
     }
 


### PR DESCRIPTION
Can't use `php artisan` when the Sitemap is disabled because the controller gets instantiated but it throws inside the constructor.

```
user@site:~/site.com$ php artisan route:list

In SitemapController.php line 19:

  [Statamic\Exceptions\NotFoundHttpException]
```