### PR TITLE
Only register sitemap routes if sitemap is enabled

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -3,7 +3,7 @@
 use Aerni\AdvancedSeo\Http\Controllers\Web\SitemapController;
 use Illuminate\Support\Facades\Route;
 
-if (config('advanced-seo.sitemap.enabled')) {
+if (config('advanced-seo.sitemap.enabled') && in_array(app()->environment(), config('advanced-seo.crawling.environments', []))) {
     Route::name('advanced-seo.')->group(function () {
         Route::get('/sitemap.xml', [SitemapController::class, 'index'])->name('sitemap.index');
         Route::get('/sitemaps/{id}.xml', [SitemapController::class, 'show'])->name('sitemap.show');

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,8 +3,10 @@
 use Aerni\AdvancedSeo\Http\Controllers\Web\SitemapController;
 use Illuminate\Support\Facades\Route;
 
-Route::name('advanced-seo.')->group(function () {
-    Route::get('/sitemap.xml', [SitemapController::class, 'index'])->name('sitemap.index');
-    Route::get('/sitemaps/{id}.xml', [SitemapController::class, 'show'])->name('sitemap.show');
-    Route::get('/sitemap.xsl', [SitemapController::class, 'xsl'])->name('sitemap.xsl');
-});
+if (config('advanced-seo.sitemap.enabled')) {
+    Route::name('advanced-seo.')->group(function () {
+        Route::get('/sitemap.xml', [SitemapController::class, 'index'])->name('sitemap.index');
+        Route::get('/sitemaps/{id}.xml', [SitemapController::class, 'show'])->name('sitemap.show');
+        Route::get('/sitemap.xsl', [SitemapController::class, 'xsl'])->name('sitemap.xsl');
+    });
+}

--- a/src/Http/Controllers/Web/SitemapController.php
+++ b/src/Http/Controllers/Web/SitemapController.php
@@ -2,7 +2,6 @@
 
 namespace Aerni\AdvancedSeo\Http\Controllers\Web;
 
-use Aerni\AdvancedSeo\Concerns\EvaluatesIndexability;
 use Aerni\AdvancedSeo\Contracts\Sitemap;
 use Aerni\AdvancedSeo\Contracts\SitemapIndex;
 use Aerni\AdvancedSeo\Facades\Sitemap as SitemapRepository;
@@ -12,14 +11,6 @@ use Statamic\Exceptions\NotFoundHttpException;
 
 class SitemapController extends Controller
 {
-    use EvaluatesIndexability;
-
-    public function __construct()
-    {
-        throw_unless(config('advanced-seo.sitemap.enabled'), new NotFoundHttpException);
-        throw_unless($this->crawlingIsEnabled(), new NotFoundHttpException);
-    }
-
     public function index(): SitemapIndex
     {
         return SitemapRepository::index();


### PR DESCRIPTION
I don't use the built-in sitemap but any other plugin or route that is bound to `/sitemap.xml` won't work because this plugin always registers the sitemap routes and then 404s when the sitemap is disabled.