### PR TITLE
Confirm Pro edition activation during install

### DIFF
--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -129,6 +129,8 @@ class Install extends Command
 
         File::put($configPath, $contents);
 
+        info('Pro edition enabled.');
+
         return true;
     }
 


### PR DESCRIPTION
Adds an `info('Pro edition enabled.')` confirmation after `seo:install` flips the edition to Pro. Matches the per-feature confirmations already printed for sitemap, AI, etc.