### PR TITLE
Prompt users to clean conflicting head tags after install

### DIFF
--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -363,6 +363,7 @@ class Install extends Command
 
             $relativePath = Str::after($path, base_path('/'));
             info("Added SEO tags to {$relativePath}.");
+            note("Review your layout's <head> and remove any existing SEO tags (title, description, Open Graph, etc.) that would conflict with {$headTag}.");
         }
     }
 


### PR DESCRIPTION
Adds a `note()` after `seo:install` injects `{{ seo:head }}` into the layout, reminding users to remove conflicting SEO tags from their existing `<head>`. Only fires when tags were actually injected.