### PR TITLE
Hide origins selector for single-site seo sets

### DIFF
--- a/src/Features/Ai.php
+++ b/src/Features/Ai.php
@@ -3,7 +3,7 @@
 namespace Aerni\AdvancedSeo\Features;
 
 use Aerni\AdvancedSeo\AdvancedSeo;
-use Aerni\AdvancedSeo\Contracts\SeoSetConfig;
+use Aerni\AdvancedSeo\SeoSets\SeoSet;
 use Statamic\Console\Processes\Composer;
 
 class Ai extends Feature
@@ -27,8 +27,8 @@ class Ai extends Feature
         return (bool) config("ai.providers.{$provider}.key");
     }
 
-    protected static function enabledInConfig(SeoSetConfig $config): bool
+    protected static function enabledInLocalization(SeoSet $set): bool
     {
-        return $config->value('ai');
+        return $set->config()->value('ai');
     }
 }

--- a/src/Features/Feature.php
+++ b/src/Features/Feature.php
@@ -3,26 +3,32 @@
 namespace Aerni\AdvancedSeo\Features;
 
 use Aerni\AdvancedSeo\Context\Context;
-use Aerni\AdvancedSeo\Contracts\SeoSetConfig;
+use Aerni\AdvancedSeo\SeoSets\SeoSet;
 use Statamic\Facades\Blink;
 
 abstract class Feature
 {
     /**
      * Whether the feature is enabled, optionally for the given context.
+     *
+     * Per-seo-set contexts run the scope-specific checks so features can gate
+     * on the set's own state (e.g. MultiSite on the sites count, Sitemap on
+     * the stored toggle). Other contexts fall back to the global availability
+     * check, because per-set state doesn't apply.
      */
     public static function enabled(?Context $context = null): bool
     {
-        $config = static::configFor($context);
-
-        if ($config === null) {
-            return Blink::once('advanced-seo::features::'.static::class, fn () => static::available());
+        if (static::seoSetFor($context)) {
+            // Blink key must start with "advanced-seo::{type}::{handle}::" to be flushed by SeoSet::flushBlink()
+            return Blink::once(
+                "advanced-seo::{$context->type}::{$context->handle}::features::".static::class."::{$context->scope->value}::{$context->site}",
+                fn () => static::available() && static::enabledInScope($context),
+            );
         }
 
-        // Key must start with "advanced-seo::{type}::{handle}::" to be flushed by SeoSet::flushBlink()
         return Blink::once(
-            "advanced-seo::{$context->type}::{$context->handle}::features::".static::class."::{$context->scope->value}::{$context->site}",
-            fn () => static::available() && $config->enabled() && static::enabledInConfig($config)
+            'advanced-seo::features::'.static::class,
+            fn () => static::available(),
         );
     }
 
@@ -32,19 +38,42 @@ abstract class Feature
     abstract protected static function available(): bool;
 
     /**
-     * Whether the feature's SeoSet-level toggle is on for the given config.
+     * Whether the feature applies when editing the given seo set's config.
+     * Avoid gating on a value that is edited via the config blueprint, or the
+     * field that configures this feature will hide itself.
      */
-    protected static function enabledInConfig(SeoSetConfig $config): bool
+    protected static function enabledInConfig(SeoSet $set): bool
     {
         return true;
     }
 
-    private static function configFor(?Context $context): ?SeoSetConfig
+    /**
+     * Whether the feature applies for the given seo set's localizations.
+     * Called for both localization-scope and content-scope contexts.
+     */
+    protected static function enabledInLocalization(SeoSet $set): bool
     {
-        if ($context === null || $context->isConfig() || $context->type === 'site') {
+        return true;
+    }
+
+    private static function seoSetFor(?Context $context): ?SeoSet
+    {
+        // Site-type configs don't carry the per-set toggles that features gate on, so fall through to available().
+        if ($context?->type === 'site') {
             return null;
         }
 
-        return $context->seoSet()?->config();
+        return $context?->seoSet();
+    }
+
+    private static function enabledInScope(Context $context): bool
+    {
+        $set = $context->seoSet();
+
+        if ($context->isConfig()) {
+            return static::enabledInConfig($set);
+        }
+
+        return $set->config()->enabled() && static::enabledInLocalization($set);
     }
 }

--- a/src/Features/MultiSite.php
+++ b/src/Features/MultiSite.php
@@ -3,6 +3,7 @@
 namespace Aerni\AdvancedSeo\Features;
 
 use Aerni\AdvancedSeo\AdvancedSeo;
+use Aerni\AdvancedSeo\SeoSets\SeoSet;
 use Statamic\Facades\Site;
 
 class MultiSite extends Feature
@@ -10,5 +11,10 @@ class MultiSite extends Feature
     protected static function available(): bool
     {
         return AdvancedSeo::pro() && Site::hasMultiple();
+    }
+
+    protected static function enabledInConfig(SeoSet $set): bool
+    {
+        return $set->sites()->count() > 1;
     }
 }

--- a/src/Features/Sitemap.php
+++ b/src/Features/Sitemap.php
@@ -3,7 +3,7 @@
 namespace Aerni\AdvancedSeo\Features;
 
 use Aerni\AdvancedSeo\AdvancedSeo;
-use Aerni\AdvancedSeo\Contracts\SeoSetConfig;
+use Aerni\AdvancedSeo\SeoSets\SeoSet;
 
 class Sitemap extends Feature
 {
@@ -12,8 +12,8 @@ class Sitemap extends Feature
         return AdvancedSeo::pro() && config('advanced-seo.sitemap.enabled', true);
     }
 
-    protected static function enabledInConfig(SeoSetConfig $config): bool
+    protected static function enabledInLocalization(SeoSet $set): bool
     {
-        return $config->value('sitemap');
+        return $set->config()->value('sitemap');
     }
 }

--- a/src/Features/SocialImagesGenerator.php
+++ b/src/Features/SocialImagesGenerator.php
@@ -3,8 +3,8 @@
 namespace Aerni\AdvancedSeo\Features;
 
 use Aerni\AdvancedSeo\AdvancedSeo;
-use Aerni\AdvancedSeo\Contracts\SeoSetConfig;
 use Aerni\AdvancedSeo\Facades\SocialImage;
+use Aerni\AdvancedSeo\SeoSets\SeoSet;
 use Statamic\Console\Processes\Composer;
 
 class SocialImagesGenerator extends Feature
@@ -26,8 +26,8 @@ class SocialImagesGenerator extends Feature
         return SocialImage::themes()->all()->isNotEmpty();
     }
 
-    protected static function enabledInConfig(SeoSetConfig $config): bool
+    protected static function enabledInLocalization(SeoSet $set): bool
     {
-        return $config->value('social_images_generator');
+        return $set->config()->value('social_images_generator');
     }
 }

--- a/tests/Features/FeatureTest.php
+++ b/tests/Features/FeatureTest.php
@@ -1,10 +1,10 @@
 <?php
 
 use Aerni\AdvancedSeo\Context\Context;
-use Aerni\AdvancedSeo\Contracts\SeoSetConfig;
 use Aerni\AdvancedSeo\Enums\Scope;
 use Aerni\AdvancedSeo\Facades\Seo;
 use Aerni\AdvancedSeo\Features\Feature;
+use Aerni\AdvancedSeo\SeoSets\SeoSet;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Site;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
@@ -24,11 +24,11 @@ it('returns available() when no context is provided', function () {
     expect(UnavailableFeature::enabled())->toBeFalse();
 });
 
-it('returns available() when the context is config-scope', function () {
+it('returns available() for site-type contexts', function () {
     $context = new Context(
-        parent: Collection::find('pages'),
-        type: 'collections',
-        handle: 'pages',
+        parent: Seo::find('site::defaults'),
+        type: 'site',
+        handle: 'defaults',
         scope: Scope::Config,
         site: 'english',
     );
@@ -98,7 +98,7 @@ it('returns available() for config-scope contexts even when the seoset is disabl
     expect(AvailableFeature::enabled($context))->toBeTrue();
 });
 
-it('consults enabledInConfig() for content-scope contexts', function () {
+it('consults enabledInLocalization() for content-scope contexts', function () {
     $context = new Context(
         parent: Collection::find('pages'),
         type: 'collections',
@@ -107,11 +107,11 @@ it('consults enabledInConfig() for content-scope contexts', function () {
         site: 'english',
     );
 
-    expect(FeatureWithConfigCheckTrue::enabled($context))->toBeTrue();
-    expect(FeatureWithConfigCheckFalse::enabled($context))->toBeFalse();
+    expect(FeatureWithLocalizationCheckTrue::enabled($context))->toBeTrue();
+    expect(FeatureWithLocalizationCheckFalse::enabled($context))->toBeFalse();
 });
 
-it('bypasses enabledInConfig() for config-scope contexts', function () {
+it('consults enabledInConfig() for config-scope contexts', function () {
     $context = new Context(
         parent: Collection::find('pages'),
         type: 'collections',
@@ -120,9 +120,36 @@ it('bypasses enabledInConfig() for config-scope contexts', function () {
         site: 'english',
     );
 
-    // Config scope bypasses the SeoSet checks entirely, so a feature whose
-    // enabledInConfig() would return false still reports enabled.
+    expect(FeatureWithConfigCheckTrue::enabled($context))->toBeTrue();
+    expect(FeatureWithConfigCheckFalse::enabled($context))->toBeFalse();
+});
+
+it('does not call enabledInConfig() for content-scope contexts', function () {
+    $context = new Context(
+        parent: Collection::find('pages'),
+        type: 'collections',
+        handle: 'pages',
+        scope: Scope::Content,
+        site: 'english',
+    );
+
+    // enabledInConfig would return false; content scope uses enabledInLocalization instead,
+    // which defaults to true.
     expect(FeatureWithConfigCheckFalse::enabled($context))->toBeTrue();
+});
+
+it('does not call enabledInLocalization() for config-scope contexts', function () {
+    $context = new Context(
+        parent: Collection::find('pages'),
+        type: 'collections',
+        handle: 'pages',
+        scope: Scope::Config,
+        site: 'english',
+    );
+
+    // enabledInLocalization would return false; config scope uses enabledInConfig instead,
+    // which defaults to true.
+    expect(FeatureWithLocalizationCheckFalse::enabled($context))->toBeTrue();
 });
 
 class AvailableFeature extends Feature
@@ -148,7 +175,7 @@ class FeatureWithConfigCheckTrue extends Feature
         return true;
     }
 
-    protected static function enabledInConfig(SeoSetConfig $config): bool
+    protected static function enabledInConfig(SeoSet $set): bool
     {
         return true;
     }
@@ -161,7 +188,33 @@ class FeatureWithConfigCheckFalse extends Feature
         return true;
     }
 
-    protected static function enabledInConfig(SeoSetConfig $config): bool
+    protected static function enabledInConfig(SeoSet $set): bool
+    {
+        return false;
+    }
+}
+
+class FeatureWithLocalizationCheckTrue extends Feature
+{
+    protected static function available(): bool
+    {
+        return true;
+    }
+
+    protected static function enabledInLocalization(SeoSet $set): bool
+    {
+        return true;
+    }
+}
+
+class FeatureWithLocalizationCheckFalse extends Feature
+{
+    protected static function available(): bool
+    {
+        return true;
+    }
+
+    protected static function enabledInLocalization(SeoSet $set): bool
     {
         return false;
     }

--- a/tests/Features/MultiSiteTest.php
+++ b/tests/Features/MultiSiteTest.php
@@ -1,7 +1,13 @@
 <?php
 
+use Aerni\AdvancedSeo\Context\Context;
+use Aerni\AdvancedSeo\Enums\Scope;
 use Aerni\AdvancedSeo\Features\MultiSite;
+use Statamic\Facades\Collection;
 use Statamic\Facades\Site;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+
+uses(PreventsSavingStacheItemsToDisk::class);
 
 it('is disabled on the free edition', function () {
     useFreeEdition();
@@ -29,4 +35,42 @@ it('is enabled on pro with multiple sites', function () {
     ]);
 
     expect(MultiSite::enabled())->toBeTrue();
+});
+
+it('is disabled for a seo set that is scoped to a single site', function () {
+    Site::setSites([
+        'english' => ['name' => 'English', 'url' => '/', 'locale' => 'en'],
+        'german' => ['name' => 'German', 'url' => '/de', 'locale' => 'de'],
+    ]);
+
+    Collection::make('pages')->sites(['english'])->saveQuietly();
+
+    $context = new Context(
+        parent: Collection::find('pages'),
+        type: 'collections',
+        handle: 'pages',
+        scope: Scope::Config,
+        site: 'english',
+    );
+
+    expect(MultiSite::enabled($context))->toBeFalse();
+});
+
+it('is enabled for a seo set that spans multiple sites', function () {
+    Site::setSites([
+        'english' => ['name' => 'English', 'url' => '/', 'locale' => 'en'],
+        'german' => ['name' => 'German', 'url' => '/de', 'locale' => 'de'],
+    ]);
+
+    Collection::make('articles')->sites(['english', 'german'])->saveQuietly();
+
+    $context = new Context(
+        parent: Collection::find('articles'),
+        type: 'collections',
+        handle: 'articles',
+        scope: Scope::Config,
+        site: 'english',
+    );
+
+    expect(MultiSite::enabled($context))->toBeTrue();
 });


### PR DESCRIPTION
Hides the origins selector on a collection/taxonomy config when the collection/taxonomy is only configured for a single site, since origins only make sense across multiple sites. Refactors the Feature base class to dispatch scope-specific checks (`enabledInConfig` / `enabledInLocalization`) through a single hook, letting the `MultiSite` feature express "this set has multiple sites" without self-hiding other features' toggle fields.