### PR TITLE
Default site_name to the matching Statamic site's name

### DIFF
--- a/src/Blueprints/SiteSeoSetLocalizationBlueprint.php
+++ b/src/Blueprints/SiteSeoSetLocalizationBlueprint.php
@@ -3,12 +3,14 @@
 namespace Aerni\AdvancedSeo\Blueprints;
 
 use Aerni\AdvancedSeo\Concerns\HasAssetField;
+use Aerni\AdvancedSeo\Context\Context;
 use Aerni\AdvancedSeo\Features\Ai;
 use Aerni\AdvancedSeo\Features\Cloudflare;
 use Aerni\AdvancedSeo\Features\Fathom;
 use Aerni\AdvancedSeo\Features\Favicons;
 use Aerni\AdvancedSeo\Features\GoogleTagManager;
 use Aerni\AdvancedSeo\Features\SiteVerification;
+use Statamic\Facades\Site;
 
 class SiteSeoSetLocalizationBlueprint extends BaseBlueprint
 {
@@ -58,6 +60,7 @@ class SiteSeoSetLocalizationBlueprint extends BaseBlueprint
                         'display' => $this->trans('site_name.display'),
                         'instructions' => $this->trans('site_name.instructions'),
                         'input_type' => 'text',
+                        'default' => $this->lazy(fn (Context $context) => Site::get($context->site)?->name()),
                         'localizable' => true,
                         'listable' => 'hidden',
                         'width' => 50,

--- a/tests/Data/SeoSetLocalizationTest.php
+++ b/tests/Data/SeoSetLocalizationTest.php
@@ -116,6 +116,16 @@ it('can get the blueprint for site defaults', function () {
     expect($blueprint->handle())->toBe('site_localization');
 });
 
+it('defaults site_name to the statamic site name on the site defaults blueprint', function () {
+    $set = Seo::find('site::defaults');
+
+    expect($set->in('english')->blueprint()->field('site_name')->defaultValue())->toBe('English');
+
+    Blink::flush();
+
+    expect($set->in('german')->blueprint()->field('site_name')->defaultValue())->toBe('German');
+});
+
 it('can get blueprint fields', function () {
     $localization = Seo::find('collections::articles')->inDefaultSite();
 


### PR DESCRIPTION
Defaults the `site_name` field on the site defaults blueprint to the corresponding Statamic site's name from `resources/sites.yaml`. Resolves lazily via the blueprint context so each localization gets its own site's name.