### PR TITLE
Fix eloquent user type error

### DIFF
--- a/src/Gates/SeoContentGate.php
+++ b/src/Gates/SeoContentGate.php
@@ -4,7 +4,7 @@ namespace Aerni\AdvancedSeo\Gates;
 
 use Aerni\AdvancedSeo\AdvancedSeo;
 use Aerni\AdvancedSeo\SeoSets\SeoSet;
-use Statamic\Facades\User as UserFacade;
+use Statamic\Facades\User;
 
 class SeoContentGate
 {
@@ -22,7 +22,7 @@ class SeoContentGate
             return false;
         }
 
-        $user = UserFacade::fromUser($user);
+        $user = User::fromUser($user);
 
         if ($user->isSuper()) {
             return true;

--- a/src/Gates/SeoContentGate.php
+++ b/src/Gates/SeoContentGate.php
@@ -4,7 +4,6 @@ namespace Aerni\AdvancedSeo\Gates;
 
 use Aerni\AdvancedSeo\AdvancedSeo;
 use Aerni\AdvancedSeo\SeoSets\SeoSet;
-use Statamic\Contracts\Auth\User;
 use Statamic\Facades\User as UserFacade;
 
 class SeoContentGate
@@ -12,7 +11,7 @@ class SeoContentGate
     /**
      * Determine if the user can access the SEO tab and edit content on entries and terms.
      */
-    public function editContent(User $user, SeoSet $seoSet): bool
+    public function editContent($user, SeoSet $seoSet): bool
     {
         if (! AdvancedSeo::pro()) {
             return true;

--- a/src/Policies/SeoSetPolicy.php
+++ b/src/Policies/SeoSetPolicy.php
@@ -6,7 +6,6 @@ use Aerni\AdvancedSeo\AdvancedSeo;
 use Aerni\AdvancedSeo\Contracts\SeoSetLocalization;
 use Aerni\AdvancedSeo\SeoSets\SeoSet;
 use Aerni\AdvancedSeo\SeoSets\SeoSetGroup;
-use Statamic\Contracts\Auth\User;
 use Statamic\Facades\User as UserFacade;
 use Statamic\Policies\Concerns\HasMultisitePolicy;
 
@@ -66,7 +65,7 @@ class SeoSetPolicy
             || $this->canEditStatamicContent($user, $seoSet->type(), $seoSet->handle());
     }
 
-    protected function canEditStatamicContent(User $user, string $type, string $handle): bool
+    protected function canEditStatamicContent($user, string $type, string $handle): bool
     {
         $itemType = match ($type) {
             'collections' => 'entries',

--- a/src/Policies/SeoSetPolicy.php
+++ b/src/Policies/SeoSetPolicy.php
@@ -14,7 +14,7 @@ class SeoSetPolicy
 {
     use HasMultisitePolicy;
 
-    public function before(User $user)
+    public function before($user)
     {
         if (! AdvancedSeo::pro()) {
             return true;
@@ -27,7 +27,7 @@ class SeoSetPolicy
         }
     }
 
-    public function viewAny(User $user, SeoSetGroup $group): bool
+    public function viewAny($user, SeoSetGroup $group): bool
     {
         $user = UserFacade::fromUser($user);
 
@@ -36,7 +36,7 @@ class SeoSetPolicy
         });
     }
 
-    public function edit(User $user, SeoSetLocalization $localization): bool
+    public function edit($user, SeoSetLocalization $localization): bool
     {
         $user = UserFacade::fromUser($user);
 
@@ -54,7 +54,7 @@ class SeoSetPolicy
         return $canEditLocalization && $this->canEditStatamicContent($user, $localization->type(), $localization->handle());
     }
 
-    public function configure(User $user, SeoSet $seoSet): bool
+    public function configure($user, SeoSet $seoSet): bool
     {
         $user = UserFacade::fromUser($user);
 

--- a/src/Policies/SeoSetPolicy.php
+++ b/src/Policies/SeoSetPolicy.php
@@ -6,7 +6,7 @@ use Aerni\AdvancedSeo\AdvancedSeo;
 use Aerni\AdvancedSeo\Contracts\SeoSetLocalization;
 use Aerni\AdvancedSeo\SeoSets\SeoSet;
 use Aerni\AdvancedSeo\SeoSets\SeoSetGroup;
-use Statamic\Facades\User as UserFacade;
+use Statamic\Facades\User;
 use Statamic\Policies\Concerns\HasMultisitePolicy;
 
 class SeoSetPolicy
@@ -19,7 +19,7 @@ class SeoSetPolicy
             return true;
         }
 
-        $user = UserFacade::fromUser($user);
+        $user = User::fromUser($user);
 
         if ($user->isSuper()) {
             return true;
@@ -28,7 +28,7 @@ class SeoSetPolicy
 
     public function viewAny($user, SeoSetGroup $group): bool
     {
-        $user = UserFacade::fromUser($user);
+        $user = User::fromUser($user);
 
         return $group->seoSets()->contains(function (SeoSet $seoSet) use ($user) {
             return $seoSet->localizations()->contains(fn (SeoSetLocalization $localization) => $this->edit($user, $localization));
@@ -37,7 +37,7 @@ class SeoSetPolicy
 
     public function edit($user, SeoSetLocalization $localization): bool
     {
-        $user = UserFacade::fromUser($user);
+        $user = User::fromUser($user);
 
         if (! $this->userCanAccessSite($user, $localization->site())) {
             return false;
@@ -55,7 +55,7 @@ class SeoSetPolicy
 
     public function configure($user, SeoSet $seoSet): bool
     {
-        $user = UserFacade::fromUser($user);
+        $user = User::fromUser($user);
 
         if (! $user->hasPermission('configure seo')) {
             return false;


### PR DESCRIPTION
Removes the `Statamic\Contracts\Auth\User` type hint from `SeoContentGate::editContent()` and the `SeoSetPolicy` methods that Laravel's Gate calls. With the eloquent users repository, Laravel passes the host app's `Authenticatable` model, which doesn't implement the contract. `UserFacade::fromUser()` already handles the conversion, so the hint was the only thing blocking non-super users from SEO pages.

This is the v3 regression of the original v2 fix in #110.

Fixes #108.