### PR TITLE
Resolve breadcrumb ancestors on sites with a URL prefix

### DIFF
--- a/src/Cascades/ContentCascade.php
+++ b/src/Cascades/ContentCascade.php
@@ -209,7 +209,7 @@ class ContentCascade extends BaseCascade
 
     protected function breadcrumbSegments(): array
     {
-        return explode('/', trim($this->model->url(), '/'));
+        return explode('/', trim($this->model->uri(), '/'));
     }
 
     public function pageSchema(): ?string

--- a/src/Cascades/ContextViewCascade.php
+++ b/src/Cascades/ContextViewCascade.php
@@ -74,6 +74,8 @@ class ContextViewCascade extends ContentViewCascade
 
     protected function breadcrumbSegments(): array
     {
-        return request()->segments();
+        $uri = Site::current()->relativePath($this->model->get('current_url'));
+
+        return explode('/', trim($uri, '/'));
     }
 }

--- a/tests/Cascades/ContentCascadeTest.php
+++ b/tests/Cascades/ContentCascadeTest.php
@@ -343,6 +343,47 @@ it('returns breadcrumbs json ld when enabled and not homepage', function () {
     }
 });
 
+it('resolves all breadcrumb ancestors on a site with a url prefix', function () {
+    $collection = Collection::make('docs')
+        ->routes('{parent_uri}/{slug}')
+        ->sites(['english', 'german'])
+        ->structureContents(['root' => true])
+        ->save();
+
+    // Rebuild the memoized SeoSet registry so the new collection is recognised.
+    flushBlink();
+
+    $home = Entry::make()->collection('docs')->locale('german')->slug('home')->data(['title' => 'Home']);
+    $home->save();
+
+    $levelOne = Entry::make()->collection('docs')->locale('german')->slug('level-1')->data(['title' => 'Level 1']);
+    $levelOne->save();
+
+    $levelTwo = Entry::make()->collection('docs')->locale('german')->slug('level-2')->data(['title' => 'Level 2']);
+    $levelTwo->save();
+
+    $collection->structure()->in('german')->tree([
+        ['entry' => $home->id()],
+        ['entry' => $levelOne->id(), 'children' => [
+            ['entry' => $levelTwo->id()],
+        ]],
+    ])->save();
+
+    flushBlink();
+
+    $cascade = ContentCascade::from(Entry::find($levelTwo->id()));
+    $cascade->set('use_breadcrumbs', true);
+
+    $items = collect(json_decode($cascade->breadcrumbs(), true)['itemListElement']);
+
+    expect($items->pluck('name')->all())->toBe(['Home', 'Level 1', 'Level 2'])
+        ->and($items->pluck('item')->all())->toBe([
+            'https://example.com/de/',
+            'https://example.com/de/level-1',
+            'https://example.com/de/level-1/level-2',
+        ]);
+});
+
 it('returns null page schema when json ld is not set', function () {
     expect($this->cascade->pageSchema())->toBeNull();
 });

--- a/tests/Cascades/ContextViewCascadeTest.php
+++ b/tests/Cascades/ContextViewCascadeTest.php
@@ -3,6 +3,7 @@
 use Aerni\AdvancedSeo\Cascades\ContextViewCascade;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
 use Statamic\Facades\Taxonomy;
 use Statamic\Tags\Context;
@@ -136,6 +137,54 @@ it('detects homepage from context is_homepage flag', function () {
 
     // Homepage should return null breadcrumbs.
     expect($cascade->breadcrumbs())->toBeNull();
+});
+
+it('resolves all breadcrumb ancestors on a site with a url prefix', function () {
+    $collection = Collection::make('docs')
+        ->routes('{parent_uri}/{slug}')
+        ->sites(['english', 'german'])
+        ->structureContents(['root' => true])
+        ->save();
+
+    // Rebuild the memoized SeoSet registry so the new collection is recognised.
+    flushBlink();
+
+    $home = Entry::make()->collection('docs')->locale('german')->slug('home')->data(['title' => 'Home']);
+    $home->save();
+
+    $levelOne = Entry::make()->collection('docs')->locale('german')->slug('level-1')->data(['title' => 'Level 1']);
+    $levelOne->save();
+
+    $levelTwo = Entry::make()->collection('docs')->locale('german')->slug('level-2')->data(['title' => 'Level 2']);
+    $levelTwo->save();
+
+    $collection->structure()->in('german')->tree([
+        ['entry' => $home->id()],
+        ['entry' => $levelOne->id(), 'children' => [
+            ['entry' => $levelTwo->id()],
+        ]],
+    ])->save();
+
+    flushBlink();
+
+    Site::setCurrent('german');
+
+    $context = new Context(collect([
+        'current_url' => 'https://example.com/de/level-1/level-2',
+        'site' => Site::get('german'),
+    ]));
+
+    $cascade = ContextViewCascade::from($context);
+    $cascade->set('use_breadcrumbs', true);
+
+    $items = collect(json_decode($cascade->breadcrumbs(), true)['itemListElement']);
+
+    expect($items->pluck('name')->all())->toBe(['Home', 'Level 1', 'Level 2'])
+        ->and($items->pluck('item')->all())->toBe([
+            'https://example.com/de/',
+            'https://example.com/de/level-1',
+            'https://example.com/de/level-1/level-2',
+        ]);
 });
 
 it('returns default title when context has a title', function () {


### PR DESCRIPTION
Fixes #219. `ResolveBreadcrumbs` built segments from `$model->url()`, which includes the site's URL prefix (`/de`, `/fr`, …), but `Data::findByUri()` matches the site-relative `uri`, so every ancestor lookup failed on prefixed sites and only Home remained. Build the segments from `uri()` instead.