### PR TITLE
Render SEO field values in entry and term listings

### DIFF
--- a/resources/js/components/fieldtypes/SeoIndexFieldtype.vue
+++ b/resources/js/components/fieldtypes/SeoIndexFieldtype.vue
@@ -1,0 +1,27 @@
+<script setup>
+import { computed, h } from 'vue';
+import { IndexFieldtype } from '@statamic/cms';
+
+const props = defineProps(IndexFieldtype.props);
+
+const text = computed(() => {
+    const value = props.value.value;
+
+    if (value === 0) return '0';
+    if (!value) return '';
+    if (typeof value !== 'string') return JSON.stringify(value);
+
+    return value.length > 50 ? `${value.substring(0, 50)}…` : value;
+});
+
+// Text fallback for child fieldtypes without a registered index component.
+const fallback = { inheritAttrs: false, render: () => h('div', text.value) };
+
+const component = computed(() => {
+    return Statamic.$app.component(props.value.component) ?? fallback;
+});
+</script>
+
+<template>
+    <component :is="component" :handle="handle" :value="value.value" :values="values" />
+</template>

--- a/resources/js/cp.js
+++ b/resources/js/cp.js
@@ -2,6 +2,7 @@ import Dashboard from './pages/Dashboard.vue';
 import Index from './pages/Index.vue';
 import Edit from './pages/Edit.vue';
 import SeoFieldtype from './components/fieldtypes/SeoFieldtype.vue'
+import SeoIndexFieldtype from './components/fieldtypes/SeoIndexFieldtype.vue'
 import SiteOriginsFieldtype from './components/fieldtypes/SiteOriginsFieldtype.vue'
 import SearchPreviewFieldtype from './components/fieldtypes/SearchPreviewFieldtype.vue'
 import SocialPreviewFieldtype from './components/fieldtypes/SocialPreviewFieldtype.vue'
@@ -17,6 +18,7 @@ Statamic.booting(() => {
     Statamic.$inertia.register('advanced-seo::Taxonomies/Index', Index)
     Statamic.$inertia.register('advanced-seo::Taxonomies/Edit', Edit)
     Statamic.$components.register('seo-fieldtype', SeoFieldtype)
+    Statamic.$components.register('seo-fieldtype-index', SeoIndexFieldtype)
     Statamic.$components.register('site_origins-fieldtype', SiteOriginsFieldtype)
     Statamic.$components.register('search_preview-fieldtype', SearchPreviewFieldtype)
     Statamic.$components.register('social_preview-fieldtype', SocialPreviewFieldtype)

--- a/src/Fieldtypes/SeoFieldtype.php
+++ b/src/Fieldtypes/SeoFieldtype.php
@@ -14,6 +14,7 @@ use Statamic\Contracts\Taxonomies\Term;
 use Statamic\Facades\Blink;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fieldtype;
+use Statamic\Fieldtypes\Assets\Assets;
 use Statamic\Fieldtypes\Code;
 
 class SeoFieldtype extends Fieldtype
@@ -121,15 +122,34 @@ class SeoFieldtype extends Fieldtype
 
     public function augment(mixed $data): mixed
     {
+        return $this->childFieldtype()->augment($this->resolveValue($data));
+    }
+
+    public function preProcessIndex(mixed $data): array
+    {
+        $childFieldtype = $this->childFieldtype();
+
+        $value = $childFieldtype instanceof Assets
+            ? $childFieldtype->preProcessIndex($this->resolveValue($data))
+            : $this->augment($data);
+
+        return [
+            'component' => "{$childFieldtype->component()}-fieldtype-index",
+            'value' => $value,
+        ];
+    }
+
+    protected function resolveValue(mixed $data): mixed
+    {
         $data ??= $this->field->defaultValue();
 
         if ($data === '@default') {
-            $data = $this->shouldUseOriginDefault()
+            return $this->shouldUseOriginDefault()
                 ? $this->originDefaultValueFromCascade()
                 : $this->defaultValueFromCascade();
         }
 
-        return $this->childFieldtype()->augment($data);
+        return $data;
     }
 
     public function preProcessValidatable(mixed $value): mixed

--- a/src/Fieldtypes/SocialImageFieldtype.php
+++ b/src/Fieldtypes/SocialImageFieldtype.php
@@ -26,6 +26,20 @@ class SocialImageFieldtype extends Assets
             : parent::augment($value);
     }
 
+    public function preProcessIndex($data)
+    {
+        if (! $this->shouldGenerateSocialImage()) {
+            return parent::preProcessIndex($data);
+        }
+
+        // Listings show an already-generated image but never generate one on render.
+        $asset = $this->generator($this->field->parent())->asset();
+
+        return $asset
+            ? parent::preProcessIndex($asset->path())
+            : ['total' => 0, 'assets' => collect()];
+    }
+
     protected function augmentGeneratedSocialImage($value)
     {
         $parent = $this->field->parent();

--- a/tests/Features/SocialImagesGeneratorTest.php
+++ b/tests/Features/SocialImagesGeneratorTest.php
@@ -7,9 +7,12 @@ use Aerni\AdvancedSeo\Features\SocialImagesGenerator;
 use Aerni\AdvancedSeo\Jobs\GenerateSocialImagesJob;
 use Aerni\AdvancedSeo\Tests\Concerns\FakesComposerLock;
 use Illuminate\Support\Facades\File;
+use Spatie\LaravelScreenshot\Facades\Screenshot;
+use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
+use Statamic\Fields\Field;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 
 uses(PreventsSavingStacheItemsToDisk::class, FakesComposerLock::class);
@@ -138,6 +141,35 @@ it('prevents the generate job on the free edition', function () {
     GenerateSocialImagesJob::dispatchSync($entry);
 
     expect($entry->get('seo_og_image'))->toBeNull();
+});
+
+it('does not generate a social image when resolving the listing index', function () {
+    Screenshot::shouldReceive('url')->never();
+
+    AssetContainer::make('assets')->disk('local')->saveQuietly();
+
+    Seo::find('collections::pages')->config()->set('social_images_generator', true)->save();
+
+    $entry = tap(Entry::make()
+        ->collection('pages')
+        ->locale('english')
+        ->slug('test')
+        ->data(['seo_generate_social_images' => true]))
+        ->saveQuietly();
+
+    // The generation path must be live for this guard test to be meaningful.
+    expect(SocialImagesGenerator::enabled(Context::from($entry)))->toBeTrue();
+
+    $field = (new Field('seo_og_image', [
+        'type' => 'social_image',
+        'container' => 'assets',
+        'max_files' => 1,
+    ]))->setParent($entry);
+
+    $result = $field->fieldtype()->preProcessIndex(null);
+
+    expect($result['total'])->toBe(0)
+        ->and($result['assets'])->toBeEmpty();
 });
 
 it('shows in all contexts when enabled', function () {

--- a/tests/Fieldtypes/SeoFieldtypeTest.php
+++ b/tests/Fieldtypes/SeoFieldtypeTest.php
@@ -203,6 +203,42 @@ it('augments null by falling through to field default', function () {
     expect($result)->toBe('Test Page | English');
 });
 
+// --- preProcessIndex ---
+
+it('preProcessIndex augments a custom value for a text child', function () {
+    $field = makeSeoFieldWithParent('seo_title');
+    $result = $field->fieldtype()->preProcessIndex('Custom Title');
+
+    expect($result)->toBe([
+        'component' => 'token_input-fieldtype-index',
+        'value' => 'Custom Title',
+    ]);
+});
+
+it('preProcessIndex resolves @default through the cascade for a text child', function () {
+    $field = makeSeoFieldWithParent('seo_title');
+    $result = $field->fieldtype()->preProcessIndex('@default');
+
+    expect($result)->toBe([
+        'component' => 'token_input-fieldtype-index',
+        'value' => 'Test Page | English',
+    ]);
+});
+
+it('preProcessIndex produces asset thumbnail data for the social image child', function () {
+    $field = makeSeoFieldWithParent('seo_og_image', [
+        'type' => 'social_image',
+        'container' => 'assets',
+        'max_files' => 1,
+    ]);
+
+    $result = $field->fieldtype()->preProcessIndex('some/image.png');
+
+    expect($result['component'])->toBe('assets-fieldtype-index')
+        ->and($result['value'])->toHaveKeys(['total', 'assets'])
+        ->and($result['value']['total'])->toBe(1);
+});
+
 // --- origin / sync: non-text fields ---
 //
 // Non-text fields (toggles, selects) without a placeholder need the UI and the


### PR DESCRIPTION
SEO columns added to entry and term listings now render real values (social image thumbnails, toggle states, resolved text) instead of the raw stored value. Social image columns only show an already-generated image and never trigger generation on listing render.