### PR TITLE
Support Antlers in custom JSON-LD

### DIFF
--- a/src/Actions/ResolveSchema.php
+++ b/src/Actions/ResolveSchema.php
@@ -2,8 +2,7 @@
 
 namespace Aerni\AdvancedSeo\Actions;
 
-use Aerni\AdvancedSeo\Cascades\SeoFieldtypeCascade;
-use Aerni\AdvancedSeo\Context\Context;
+use Aerni\AdvancedSeo\Facades\Seo;
 use Aerni\AdvancedSeo\Support\Helpers;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Contracts\Taxonomies\Term;
@@ -43,7 +42,7 @@ class ResolveSchema
 
     /**
      * Variables ordered from lowest to highest precedence, so the entry's own
-     * data wins over config, globals and SEO defaults.
+     * data wins over config, globals and site defaults.
      *
      * @return array<string, mixed>
      */
@@ -52,7 +51,7 @@ class ResolveSchema
         $model = Helpers::localizedContent($model);
 
         return Blink::once("advanced-seo::schema-context::{$model->id()}::{$model->locale()}", fn () => [
-            ...static::seoDefaults(Context::from($model)),
+            ...static::siteDefaults($model->site()),
             ...static::globals($model->site()),
             'config' => Cascade::config(),
             'current_url' => $model->absoluteUrl(),
@@ -65,25 +64,30 @@ class ResolveSchema
      */
     protected static function contextVariables(ViewContext $model): array
     {
+        $site = $model->get('site') ?? Site::current();
+
         return [
-            ...static::seoDefaults(Context::from($model)),
-            ...static::globals($model->get('site') ?? Site::current()),
+            ...static::siteDefaults($site),
+            ...static::globals($site),
             'config' => Cascade::config(),
             ...$model->all(),
         ];
     }
 
     /**
-     * The resolved SEO field values (site and content defaults, de-prefixed).
-     * The context is null for custom routes that resolve to no SEO set.
+     * The site-level SEO defaults (e.g. site_name), de-prefixed. Content
+     * defaults are excluded as they only serve to cascade into entry fields.
      *
      * @return array<string, mixed>
      */
-    protected static function seoDefaults(?Context $context): array
+    protected static function siteDefaults(SiteInstance $site): array
     {
-        return $context
-            ? SeoFieldtypeCascade::from($context)->data()->except(static::$schemaKeys)->all()
-            : [];
+        return Seo::find('site::defaults')->in($site->handle())
+            ->toAugmentedCollection()
+            ->map->value()
+            ->mapWithKeys(fn ($value, $key) => [Str::remove('seo_', $key) => $value])
+            ->except(static::$schemaKeys)
+            ->all();
     }
 
     /**

--- a/src/Actions/ResolveSchema.php
+++ b/src/Actions/ResolveSchema.php
@@ -19,14 +19,6 @@ use Statamic\View\Cascade;
 class ResolveSchema
 {
     /**
-     * Field handles currently being parsed, to bail on re-entry and prevent
-     * infinite recursion across nested augmentation.
-     *
-     * @var array<int, string>
-     */
-    protected static array $parsing = [];
-
-    /**
      * Schema-producing keys removed from the variable set so a reference to
      * them resolves to empty instead of re-augmenting.
      *
@@ -34,14 +26,10 @@ class ResolveSchema
      */
     protected static array $schemaKeys = ['json_ld', 'site_json_ld', 'site_schema', 'page_schema'];
 
-    public static function handle(?string $value, mixed $model, string $handle): ?string
+    public static function handle(?string $value, mixed $model): ?string
     {
         if ($value === null || ! Str::contains($value, '{{')) {
             return $value;
-        }
-
-        if (in_array($handle, static::$parsing, true)) {
-            return null;
         }
 
         $variables = static::variables($model);
@@ -50,13 +38,7 @@ class ResolveSchema
             return $value;
         }
 
-        static::$parsing[] = $handle;
-
-        try {
-            return Antlers::parse($value, $variables);
-        } finally {
-            array_pop(static::$parsing);
-        }
+        return Antlers::parse($value, $variables);
     }
 
     /**

--- a/src/Actions/ResolveSchema.php
+++ b/src/Actions/ResolveSchema.php
@@ -42,19 +42,22 @@ class ResolveSchema
     }
 
     /**
+     * Variables ordered from lowest to highest precedence, so the entry's own
+     * data wins over config, globals and SEO defaults.
+     *
      * @return array<string, mixed>
      */
     protected static function contentVariables(Entry|Term $model): array
     {
         $model = Helpers::localizedContent($model);
 
-        return Blink::once("advanced-seo::schema-context::{$model->id()}::{$model->locale()}", function () use ($model) {
-            return array_merge(
-                static::baseVariables(Context::from($model), $model->site()),
-                ['current_url' => $model->absoluteUrl()],
-                $model->toAugmentedArray(),
-            );
-        });
+        return Blink::once("advanced-seo::schema-context::{$model->id()}::{$model->locale()}", fn () => [
+            ...static::seoDefaults(Context::from($model)),
+            ...static::globals($model->site()),
+            'config' => Cascade::config(),
+            'current_url' => $model->absoluteUrl(),
+            ...$model->toAugmentedArray(),
+        ]);
     }
 
     /**
@@ -62,24 +65,25 @@ class ResolveSchema
      */
     protected static function contextVariables(ViewContext $model): array
     {
-        $site = $model->get('site') ?? Site::current();
-
-        return array_merge(
-            static::baseVariables(Context::from($model), $site),
-            $model->all(),
-        );
+        return [
+            ...static::seoDefaults(Context::from($model)),
+            ...static::globals($model->get('site') ?? Site::current()),
+            'config' => Cascade::config(),
+            ...$model->all(),
+        ];
     }
 
     /**
+     * The resolved SEO field values (site and content defaults, de-prefixed).
+     * The context is null for custom routes that resolve to no SEO set.
+     *
      * @return array<string, mixed>
      */
-    protected static function baseVariables(?Context $context, SiteInstance $site): array
+    protected static function seoDefaults(?Context $context): array
     {
-        $seo = $context ? SeoFieldtypeCascade::from($context)->data()->all() : [];
-
-        $seo = collect($seo)->except(static::$schemaKeys)->all();
-
-        return array_merge($seo, static::globals($site), ['config' => Cascade::config()]);
+        return $context
+            ? SeoFieldtypeCascade::from($context)->data()->except(static::$schemaKeys)->all()
+            : [];
     }
 
     /**

--- a/src/Actions/ResolveSchema.php
+++ b/src/Actions/ResolveSchema.php
@@ -26,32 +26,19 @@ class ResolveSchema
      */
     protected static array $schemaKeys = ['json_ld', 'site_json_ld', 'site_schema', 'page_schema'];
 
-    public static function handle(?string $value, mixed $model): ?string
+    public static function handle(?string $value, Entry|Term|ViewContext $model): ?string
     {
         if ($value === null || ! Str::contains($value, '{{')) {
             return $value;
         }
 
-        $variables = static::variables($model);
-
-        if ($variables === null) {
-            return $value;
-        }
-
-        return Antlers::parse($value, $variables);
-    }
-
-    /**
-     * @return array<string, mixed>|null
-     */
-    protected static function variables(mixed $model): ?array
-    {
-        return match (true) {
+        $variables = match (true) {
             $model instanceof Entry,
             $model instanceof Term => static::contentVariables($model),
             $model instanceof ViewContext => static::contextVariables($model),
-            default => null,
         };
+
+        return Antlers::parse($value, $variables);
     }
 
     /**

--- a/src/Actions/ResolveSchema.php
+++ b/src/Actions/ResolveSchema.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Aerni\AdvancedSeo\Actions;
+
+use Aerni\AdvancedSeo\Cascades\SeoFieldtypeCascade;
+use Aerni\AdvancedSeo\Context\Context;
+use Aerni\AdvancedSeo\Support\Helpers;
+use Statamic\Contracts\Entries\Entry;
+use Statamic\Contracts\Taxonomies\Term;
+use Statamic\Facades\Antlers;
+use Statamic\Facades\Blink;
+use Statamic\Facades\GlobalSet;
+use Statamic\Facades\Site;
+use Statamic\Sites\Site as SiteInstance;
+use Statamic\Support\Str;
+use Statamic\Tags\Context as ViewContext;
+use Statamic\View\Cascade;
+
+class ResolveSchema
+{
+    /**
+     * Field handles currently being parsed, to bail on re-entry and prevent
+     * infinite recursion across nested augmentation.
+     *
+     * @var array<int, string>
+     */
+    protected static array $parsing = [];
+
+    /**
+     * Schema-producing keys removed from the variable set so a reference to
+     * them resolves to empty instead of re-augmenting.
+     *
+     * @var array<int, string>
+     */
+    protected static array $schemaKeys = ['json_ld', 'site_json_ld', 'site_schema', 'page_schema'];
+
+    public static function handle(?string $value, mixed $model, string $handle): ?string
+    {
+        if ($value === null || ! Str::contains($value, '{{')) {
+            return $value;
+        }
+
+        if (in_array($handle, static::$parsing, true)) {
+            return null;
+        }
+
+        $variables = static::variables($model);
+
+        if ($variables === null) {
+            return $value;
+        }
+
+        static::$parsing[] = $handle;
+
+        try {
+            return Antlers::parse($value, $variables);
+        } finally {
+            array_pop(static::$parsing);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    protected static function variables(mixed $model): ?array
+    {
+        return match (true) {
+            $model instanceof Entry,
+            $model instanceof Term => static::contentVariables($model),
+            $model instanceof ViewContext => static::contextVariables($model),
+            default => null,
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected static function contentVariables(Entry|Term $model): array
+    {
+        $model = Helpers::localizedContent($model);
+
+        return Blink::once("advanced-seo::schema-context::{$model->id()}::{$model->locale()}", function () use ($model) {
+            return array_merge(
+                static::baseVariables(Context::from($model), $model->site()),
+                ['current_url' => $model->absoluteUrl()],
+                $model->toAugmentedArray(),
+            );
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected static function contextVariables(ViewContext $model): array
+    {
+        $site = $model->get('site') ?? Site::current();
+
+        return array_merge(
+            static::baseVariables(Context::from($model), $site),
+            $model->all(),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected static function baseVariables(?Context $context, SiteInstance $site): array
+    {
+        $seo = $context ? SeoFieldtypeCascade::from($context)->data()->all() : [];
+
+        $seo = collect($seo)->except(static::$schemaKeys)->all();
+
+        return array_merge($seo, static::globals($site), ['config' => Cascade::config()]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected static function globals(SiteInstance $site): array
+    {
+        $variables = [];
+
+        foreach (GlobalSet::all() as $set) {
+            if (! $localized = $set->in($site->handle())) {
+                continue;
+            }
+
+            if ($set->handle() === 'global') {
+                $variables = array_merge($variables, $localized->toDeferredAugmentedArray());
+            } else {
+                $variables[$set->handle()] = $localized;
+            }
+        }
+
+        return $variables;
+    }
+}

--- a/src/Actions/ResolveSchema.php
+++ b/src/Actions/ResolveSchema.php
@@ -91,24 +91,20 @@ class ResolveSchema
     }
 
     /**
+     * Global sets as template variables, mirroring Statamic: the default
+     * "global" set is flattened to the top level, the rest namespaced
+     * under their handle.
+     *
      * @return array<string, mixed>
      */
     protected static function globals(SiteInstance $site): array
     {
-        $variables = [];
-
-        foreach (GlobalSet::all() as $set) {
-            if (! $localized = $set->in($site->handle())) {
-                continue;
-            }
-
-            if ($set->handle() === 'global') {
-                $variables = array_merge($variables, $localized->toDeferredAugmentedArray());
-            } else {
-                $variables[$set->handle()] = $localized;
-            }
-        }
-
-        return $variables;
+        return GlobalSet::all()
+            ->map->in($site->handle())
+            ->filter()
+            ->flatMap(fn ($set) => $set->handle() === 'global'
+                ? $set->toDeferredAugmentedArray()
+                : [$set->handle() => $set])
+            ->all();
     }
 }

--- a/src/Actions/ResolveSchema.php
+++ b/src/Actions/ResolveSchema.php
@@ -28,7 +28,7 @@ class ResolveSchema
 
     public static function handle(?string $value, Entry|Term|ViewContext $model): ?string
     {
-        if ($value === null || ! Str::contains($value, '{{')) {
+        if (! Str::contains($value, '{{')) {
             return $value;
         }
 

--- a/src/Cascades/ContentCascade.php
+++ b/src/Cascades/ContentCascade.php
@@ -154,7 +154,7 @@ class ContentCascade extends BaseCascade
         }
 
         if ($type === 'custom') {
-            $schema = ResolveSchema::handle((string) $this->get('site_json_ld'), $this->model, 'site_json_ld');
+            $schema = ResolveSchema::handle((string) $this->get('site_json_ld'), $this->model);
 
             return blank($schema) ? null : $schema;
         }

--- a/src/Cascades/ContentCascade.php
+++ b/src/Cascades/ContentCascade.php
@@ -154,15 +154,9 @@ class ContentCascade extends BaseCascade
         }
 
         if ($type === 'custom') {
-            $schema = $this->get('site_json_ld');
+            $schema = ResolveSchema::handle((string) $this->get('site_json_ld'), $this->model, 'site_json_ld');
 
-            if ($schema === null) {
-                return null;
-            }
-
-            $parsed = ResolveSchema::handle((string) $schema, $this->model, 'site_json_ld');
-
-            return Str::of($parsed ?? '')->trim()->isEmpty() ? null : $parsed;
+            return Str::of($schema ?? '')->trim()->isEmpty() ? null : $schema;
         }
 
         $siteUrl = $this->siteUrl();

--- a/src/Cascades/ContentCascade.php
+++ b/src/Cascades/ContentCascade.php
@@ -3,6 +3,7 @@
 namespace Aerni\AdvancedSeo\Cascades;
 
 use Aerni\AdvancedSeo\Actions\ResolveBreadcrumbs;
+use Aerni\AdvancedSeo\Actions\ResolveSchema;
 use Aerni\AdvancedSeo\Concerns\EvaluatesIndexability;
 use Aerni\AdvancedSeo\Concerns\HasComputedData;
 use Aerni\AdvancedSeo\Concerns\HasHreflang;
@@ -153,7 +154,15 @@ class ContentCascade extends BaseCascade
         }
 
         if ($type === 'custom') {
-            return $this->get('site_json_ld');
+            $schema = $this->get('site_json_ld');
+
+            if ($schema === null) {
+                return null;
+            }
+
+            $parsed = ResolveSchema::handle((string) $schema, $this->model, 'site_json_ld');
+
+            return Str::of($parsed ?? '')->trim()->isEmpty() ? null : $parsed;
         }
 
         $siteUrl = $this->siteUrl();

--- a/src/Cascades/ContentCascade.php
+++ b/src/Cascades/ContentCascade.php
@@ -156,7 +156,7 @@ class ContentCascade extends BaseCascade
         if ($type === 'custom') {
             $schema = ResolveSchema::handle((string) $this->get('site_json_ld'), $this->model, 'site_json_ld');
 
-            return Str::of($schema ?? '')->trim()->isEmpty() ? null : $schema;
+            return blank($schema) ? null : $schema;
         }
 
         $siteUrl = $this->siteUrl();

--- a/src/Fieldtypes/JsonLdFieldtype.php
+++ b/src/Fieldtypes/JsonLdFieldtype.php
@@ -3,6 +3,8 @@
 namespace Aerni\AdvancedSeo\Fieldtypes;
 
 use Aerni\AdvancedSeo\Actions\ResolveSchema;
+use Statamic\Contracts\Entries\Entry;
+use Statamic\Contracts\Taxonomies\Term;
 use Statamic\Fieldtypes\Code;
 
 class JsonLdFieldtype extends Code
@@ -28,7 +30,13 @@ class JsonLdFieldtype extends Code
         static::$augmenting = true;
 
         try {
-            return parent::augment(ResolveSchema::handle($value, $this->field->parent()));
+            $parent = $this->field->parent();
+
+            return parent::augment(match (true) {
+                $parent instanceof Entry,
+                $parent instanceof Term => ResolveSchema::handle($value, $parent),
+                default => $value,
+            });
         } finally {
             static::$augmenting = false;
         }

--- a/src/Fieldtypes/JsonLdFieldtype.php
+++ b/src/Fieldtypes/JsonLdFieldtype.php
@@ -2,7 +2,7 @@
 
 namespace Aerni\AdvancedSeo\Fieldtypes;
 
-use Aerni\AdvancedSeo\Facades\Token;
+use Aerni\AdvancedSeo\Actions\ResolveSchema;
 use Statamic\Fieldtypes\Code;
 
 class JsonLdFieldtype extends Code
@@ -15,7 +15,7 @@ class JsonLdFieldtype extends Code
     {
         $value = is_array($value) ? $value['code'] : $value;
 
-        $parsed = Token::parse($value, $this->field);
+        $parsed = ResolveSchema::handle($value, $this->field->parent(), $this->field->handle());
 
         return parent::augment($parsed);
     }

--- a/src/Fieldtypes/JsonLdFieldtype.php
+++ b/src/Fieldtypes/JsonLdFieldtype.php
@@ -11,12 +11,26 @@ class JsonLdFieldtype extends Code
 
     protected $selectable = false;
 
+    /**
+     * Whether a schema is currently being augmented, used to bail on re-entry
+     * (e.g. a schema referencing its own field) and prevent infinite recursion.
+     */
+    protected static bool $augmenting = false;
+
     public function augment($value)
     {
         $value = is_array($value) ? $value['code'] : $value;
 
-        $parsed = ResolveSchema::handle($value, $this->field->parent(), $this->field->handle());
+        if (static::$augmenting) {
+            return parent::augment(null);
+        }
 
-        return parent::augment($parsed);
+        static::$augmenting = true;
+
+        try {
+            return parent::augment(ResolveSchema::handle($value, $this->field->parent()));
+        } finally {
+            static::$augmenting = false;
+        }
     }
 }

--- a/src/Tokens/TokenParser.php
+++ b/src/Tokens/TokenParser.php
@@ -44,7 +44,7 @@ class TokenParser
         try {
             $variables = $this->cascade($parent)->data()
                 ->merge($parent->toAugmentedArray())
-                ->when($field->type() !== 'json_ld', fn ($data) => $data->map($this->toPlainText(...)))
+                ->map($this->toPlainText(...))
                 ->all();
 
             return Antlers::parse($data, $variables);

--- a/tests/Actions/ResolveSchemaTest.php
+++ b/tests/Actions/ResolveSchemaTest.php
@@ -54,6 +54,14 @@ it('resolves global tokens under the set handle', function () {
     expect(ResolveSchema::handle('{{ company:tagline }}', $this->entry))->toBe('We build things');
 });
 
+it('flattens the default global set to the top level', function () {
+    $set = GlobalSet::make('global')->sites(['english']);
+    $set->save();
+    $set->in('english')->data(['tagline' => 'Top level'])->save();
+
+    expect(ResolveSchema::handle('{{ tagline }}', $this->entry))->toBe('Top level');
+});
+
 it('derives current_url from the model', function () {
     expect(ResolveSchema::handle('{{ current_url }}', $this->entry))
         ->toBe($this->entry->absoluteUrl());

--- a/tests/Actions/ResolveSchemaTest.php
+++ b/tests/Actions/ResolveSchemaTest.php
@@ -23,18 +23,18 @@ beforeEach(function () {
 });
 
 it('resolves page tokens against the model', function () {
-    expect(ResolveSchema::handle('{"name": "{{ title }}"}', $this->entry, 'seo_json_ld'))
+    expect(ResolveSchema::handle('{"name": "{{ title }}"}', $this->entry))
         ->toBe('{"name": "About"}');
 });
 
 it('applies modifiers', function () {
-    expect(ResolveSchema::handle('{{ title | upper }}', $this->entry, 'seo_json_ld'))->toBe('ABOUT');
+    expect(ResolveSchema::handle('{{ title | upper }}', $this->entry))->toBe('ABOUT');
 });
 
 it('resolves config tokens', function () {
     config()->set('app.name', 'Acme Inc');
 
-    expect(ResolveSchema::handle('{{ config:app:name }}', $this->entry, 'seo_json_ld'))->toBe('Acme Inc');
+    expect(ResolveSchema::handle('{{ config:app:name }}', $this->entry))->toBe('Acme Inc');
 });
 
 it('resolves global tokens under the set handle', function () {
@@ -42,40 +42,40 @@ it('resolves global tokens under the set handle', function () {
     $set->save();
     $set->in('english')->data(['tagline' => 'We build things'])->save();
 
-    expect(ResolveSchema::handle('{{ company:tagline }}', $this->entry, 'seo_json_ld'))->toBe('We build things');
+    expect(ResolveSchema::handle('{{ company:tagline }}', $this->entry))->toBe('We build things');
 });
 
 it('derives current_url from the model', function () {
-    expect(ResolveSchema::handle('{{ current_url }}', $this->entry, 'seo_json_ld'))
+    expect(ResolveSchema::handle('{{ current_url }}', $this->entry))
         ->toBe($this->entry->absoluteUrl());
 });
 
 it('does not leak variables between entries in the same collection', function () {
     $other = tap(Entry::make()->collection('pages')->locale('english')->slug('contact')->data(['title' => 'Contact']))->save();
 
-    expect(ResolveSchema::handle('{{ title }}', $this->entry, 'seo_json_ld'))->toBe('About');
-    expect(ResolveSchema::handle('{{ title }}', $other, 'seo_json_ld'))->toBe('Contact');
+    expect(ResolveSchema::handle('{{ title }}', $this->entry))->toBe('About');
+    expect(ResolveSchema::handle('{{ title }}', $other))->toBe('Contact');
 });
 
 it('resolves against a localized entry', function () {
     $german = tap($this->entry->makeLocalization('german')->slug('ueber-uns')->data(['title' => 'Über uns']))->save();
 
-    expect(ResolveSchema::handle('{{ title }}', $german, 'seo_json_ld'))->toBe('Über uns');
+    expect(ResolveSchema::handle('{{ title }}', $german))->toBe('Über uns');
 });
 
 it('returns the raw value when there is no content context', function () {
-    expect(ResolveSchema::handle('{{ title }}', null, 'seo_json_ld'))->toBe('{{ title }}');
+    expect(ResolveSchema::handle('{{ title }}', null))->toBe('{{ title }}');
 });
 
 it('returns null when the value is null', function () {
-    expect(ResolveSchema::handle(null, $this->entry, 'seo_json_ld'))->toBeNull();
+    expect(ResolveSchema::handle(null, $this->entry))->toBeNull();
 });
 
 it('returns token-free values unchanged', function () {
-    expect(ResolveSchema::handle('{"@type": "Organization"}', $this->entry, 'seo_json_ld'))
+    expect(ResolveSchema::handle('{"@type": "Organization"}', $this->entry))
         ->toBe('{"@type": "Organization"}');
 });
 
-it('does not recurse on a self-reference', function () {
-    expect(ResolveSchema::handle('a{{ json_ld }}b', $this->entry, 'seo_json_ld'))->toBe('ab');
+it('removes schema keys from the variable set', function () {
+    expect(ResolveSchema::handle('a{{ json_ld }}b', $this->entry))->toBe('ab');
 });

--- a/tests/Actions/ResolveSchemaTest.php
+++ b/tests/Actions/ResolveSchemaTest.php
@@ -77,6 +77,5 @@ it('returns token-free values unchanged', function () {
 });
 
 it('does not recurse on a self-reference', function () {
-    // json_ld is unset from the variable set, so it resolves to empty.
     expect(ResolveSchema::handle('a{{ json_ld }}b', $this->entry, 'seo_json_ld'))->toBe('ab');
 });

--- a/tests/Actions/ResolveSchemaTest.php
+++ b/tests/Actions/ResolveSchemaTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Aerni\AdvancedSeo\Actions\ResolveSchema;
+use Aerni\AdvancedSeo\Facades\Seo;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -35,6 +36,14 @@ it('resolves config tokens', function () {
     config()->set('app.name', 'Acme Inc');
 
     expect(ResolveSchema::handle('{{ config:app:name }}', $this->entry))->toBe('Acme Inc');
+});
+
+it('resolves site default tokens', function () {
+    $defaults = Seo::find('site::defaults')->in('english');
+    $defaults->set('site_name', 'My Site');
+    $defaults->save();
+
+    expect(ResolveSchema::handle('{{ site_name }}', $this->entry))->toBe('My Site');
 });
 
 it('resolves global tokens under the set handle', function () {

--- a/tests/Actions/ResolveSchemaTest.php
+++ b/tests/Actions/ResolveSchemaTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use Aerni\AdvancedSeo\Actions\ResolveSchema;
+use Statamic\Facades\AssetContainer;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Facades\GlobalSet;
+use Statamic\Facades\Site;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+
+uses(PreventsSavingStacheItemsToDisk::class);
+
+beforeEach(function () {
+    Site::setSites([
+        'english' => ['name' => 'English', 'url' => 'https://example.com', 'locale' => 'en'],
+        'german' => ['name' => 'German', 'url' => 'https://example.com/de', 'locale' => 'de'],
+    ]);
+
+    AssetContainer::make('assets')->disk('local')->saveQuietly();
+    Collection::make('pages')->routes('/{slug}')->sites(['english', 'german'])->saveQuietly();
+
+    $this->entry = tap(Entry::make()->collection('pages')->locale('english')->slug('about')->data(['title' => 'About']))->save();
+});
+
+it('resolves page tokens against the model', function () {
+    expect(ResolveSchema::handle('{"name": "{{ title }}"}', $this->entry, 'seo_json_ld'))
+        ->toBe('{"name": "About"}');
+});
+
+it('applies modifiers', function () {
+    expect(ResolveSchema::handle('{{ title | upper }}', $this->entry, 'seo_json_ld'))->toBe('ABOUT');
+});
+
+it('resolves config tokens', function () {
+    config()->set('app.name', 'Acme Inc');
+
+    expect(ResolveSchema::handle('{{ config:app:name }}', $this->entry, 'seo_json_ld'))->toBe('Acme Inc');
+});
+
+it('resolves global tokens under the set handle', function () {
+    $set = GlobalSet::make('company')->sites(['english']);
+    $set->save();
+    $set->in('english')->data(['tagline' => 'We build things'])->save();
+
+    expect(ResolveSchema::handle('{{ company:tagline }}', $this->entry, 'seo_json_ld'))->toBe('We build things');
+});
+
+it('derives current_url from the model', function () {
+    expect(ResolveSchema::handle('{{ current_url }}', $this->entry, 'seo_json_ld'))
+        ->toBe($this->entry->absoluteUrl());
+});
+
+it('does not leak variables between entries in the same collection', function () {
+    $other = tap(Entry::make()->collection('pages')->locale('english')->slug('contact')->data(['title' => 'Contact']))->save();
+
+    expect(ResolveSchema::handle('{{ title }}', $this->entry, 'seo_json_ld'))->toBe('About');
+    expect(ResolveSchema::handle('{{ title }}', $other, 'seo_json_ld'))->toBe('Contact');
+});
+
+it('resolves against a localized entry', function () {
+    $german = tap($this->entry->makeLocalization('german')->slug('ueber-uns')->data(['title' => 'Über uns']))->save();
+
+    expect(ResolveSchema::handle('{{ title }}', $german, 'seo_json_ld'))->toBe('Über uns');
+});
+
+it('returns the raw value when there is no content context', function () {
+    expect(ResolveSchema::handle('{{ title }}', null, 'seo_json_ld'))->toBe('{{ title }}');
+});
+
+it('returns null when the value is null', function () {
+    expect(ResolveSchema::handle(null, $this->entry, 'seo_json_ld'))->toBeNull();
+});
+
+it('returns token-free values unchanged', function () {
+    expect(ResolveSchema::handle('{"@type": "Organization"}', $this->entry, 'seo_json_ld'))
+        ->toBe('{"@type": "Organization"}');
+});
+
+it('does not recurse on a self-reference', function () {
+    // json_ld is unset from the variable set, so it resolves to empty.
+    expect(ResolveSchema::handle('a{{ json_ld }}b', $this->entry, 'seo_json_ld'))->toBe('ab');
+});

--- a/tests/Actions/ResolveSchemaTest.php
+++ b/tests/Actions/ResolveSchemaTest.php
@@ -63,10 +63,6 @@ it('resolves against a localized entry', function () {
     expect(ResolveSchema::handle('{{ title }}', $german))->toBe('Über uns');
 });
 
-it('returns the raw value when there is no content context', function () {
-    expect(ResolveSchema::handle('{{ title }}', null))->toBe('{{ title }}');
-});
-
 it('returns null when the value is null', function () {
     expect(ResolveSchema::handle(null, $this->entry))->toBeNull();
 });

--- a/tests/Cascades/ContentCascadeTest.php
+++ b/tests/Cascades/ContentCascadeTest.php
@@ -474,6 +474,14 @@ it('resolves page and config tokens in content json_ld', function () {
     expect($cascade->pageSchema())->toBe('{"name": "About", "publisher": "Acme Inc"}');
 });
 
+it('does not infinitely recurse when content json_ld references its own field', function () {
+    $this->entry->set('seo_json_ld', '{{ seo_json_ld }}')->save();
+
+    $cascade = ContentCascade::from($this->entry);
+
+    expect($cascade->pageSchema())->toBe('');
+});
+
 it('allows indexing when neither site default nor entry sets noindex', function () {
     config(['advanced-seo.crawling.environments' => ['testing']]);
 

--- a/tests/Cascades/ContentCascadeTest.php
+++ b/tests/Cascades/ContentCascadeTest.php
@@ -464,6 +464,16 @@ it('respects entry-level noindex when site default does not force it', function 
         ->and($cascade->indexing())->toContain('noindex');
 });
 
+it('resolves page and config tokens in content json_ld', function () {
+    config()->set('app.name', 'Acme Inc');
+
+    $this->entry->set('seo_json_ld', '{"name": "{{ title }}", "publisher": "{{ config:app:name }}"}')->save();
+
+    $cascade = ContentCascade::from($this->entry);
+
+    expect($cascade->pageSchema())->toBe('{"name": "About", "publisher": "Acme Inc"}');
+});
+
 it('allows indexing when neither site default nor entry sets noindex', function () {
     config(['advanced-seo.crawling.environments' => ['testing']]);
 

--- a/tests/Cascades/ContentCascadeTest.php
+++ b/tests/Cascades/ContentCascadeTest.php
@@ -490,3 +490,46 @@ it('allows indexing when neither site default nor entry sets noindex', function 
     expect($cascade->get('noindex'))->toBeFalse()
         ->and($cascade->indexing())->toBeNull();
 });
+
+it('resolves page tokens in custom site schema', function () {
+    $this->cascade->set('site_json_ld_type', new LabeledValue('custom', 'Custom'));
+    $this->cascade->set('site_json_ld', '{"@type": "WebSite", "name": "{{ title }}"}');
+
+    expect($this->cascade->siteSchema())->toBe('{"@type": "WebSite", "name": "About"}');
+});
+
+it('resolves config tokens in custom site schema', function () {
+    config()->set('app.name', 'Acme Inc');
+
+    $this->cascade->set('site_json_ld_type', new LabeledValue('custom', 'Custom'));
+    $this->cascade->set('site_json_ld', '{"publisher": "{{ config:app:name }}"}');
+
+    expect($this->cascade->siteSchema())->toBe('{"publisher": "Acme Inc"}');
+});
+
+it('normalizes empty custom site schema to null', function () {
+    $this->cascade->set('site_json_ld_type', new LabeledValue('custom', 'Custom'));
+    $this->cascade->set('site_json_ld', '');
+
+    expect($this->cascade->siteSchema())->toBeNull();
+});
+
+it('leaves token-free custom site schema unchanged', function () {
+    $this->cascade->set('site_json_ld_type', new LabeledValue('custom', 'Custom'));
+    $this->cascade->set('site_json_ld', '{"@type": "Organization"}');
+
+    expect($this->cascade->siteSchema())->toBe('{"@type": "Organization"}');
+});
+
+it('resolves tokens in site defaults set through the seo set', function () {
+    Blink::flush();
+
+    $defaults = Seo::find('site::defaults')->in('english');
+    $defaults->set('site_json_ld_type', 'custom');
+    $defaults->set('site_json_ld', '{"name": "{{ title }}"}');
+    $defaults->save();
+
+    $cascade = ContentCascade::from($this->entry);
+
+    expect($cascade->siteSchema())->toBe('{"name": "About"}');
+});

--- a/tests/Cascades/ContentCascadeTest.php
+++ b/tests/Cascades/ContentCascadeTest.php
@@ -492,44 +492,55 @@ it('allows indexing when neither site default nor entry sets noindex', function 
 });
 
 it('resolves page tokens in custom site schema', function () {
-    $this->cascade->set('site_json_ld_type', new LabeledValue('custom', 'Custom'));
-    $this->cascade->set('site_json_ld', '{"@type": "WebSite", "name": "{{ title }}"}');
+    Blink::flush();
 
-    expect($this->cascade->siteSchema())->toBe('{"@type": "WebSite", "name": "About"}');
+    $defaults = Seo::find('site::defaults')->in('english');
+    $defaults->set('site_json_ld_type', 'custom');
+    $defaults->set('site_json_ld', '{"@type": "WebSite", "name": "{{ title }}"}');
+    $defaults->save();
+
+    $cascade = ContentCascade::from($this->entry);
+
+    expect($cascade->siteSchema())->toBe('{"@type": "WebSite", "name": "About"}');
 });
 
 it('resolves config tokens in custom site schema', function () {
     config()->set('app.name', 'Acme Inc');
 
-    $this->cascade->set('site_json_ld_type', new LabeledValue('custom', 'Custom'));
-    $this->cascade->set('site_json_ld', '{"publisher": "{{ config:app:name }}"}');
-
-    expect($this->cascade->siteSchema())->toBe('{"publisher": "Acme Inc"}');
-});
-
-it('normalizes empty custom site schema to null', function () {
-    $this->cascade->set('site_json_ld_type', new LabeledValue('custom', 'Custom'));
-    $this->cascade->set('site_json_ld', '');
-
-    expect($this->cascade->siteSchema())->toBeNull();
-});
-
-it('leaves token-free custom site schema unchanged', function () {
-    $this->cascade->set('site_json_ld_type', new LabeledValue('custom', 'Custom'));
-    $this->cascade->set('site_json_ld', '{"@type": "Organization"}');
-
-    expect($this->cascade->siteSchema())->toBe('{"@type": "Organization"}');
-});
-
-it('resolves tokens in site defaults set through the seo set', function () {
     Blink::flush();
 
     $defaults = Seo::find('site::defaults')->in('english');
     $defaults->set('site_json_ld_type', 'custom');
-    $defaults->set('site_json_ld', '{"name": "{{ title }}"}');
+    $defaults->set('site_json_ld', '{"publisher": "{{ config:app:name }}"}');
     $defaults->save();
 
     $cascade = ContentCascade::from($this->entry);
 
-    expect($cascade->siteSchema())->toBe('{"name": "About"}');
+    expect($cascade->siteSchema())->toBe('{"publisher": "Acme Inc"}');
+});
+
+it('normalizes empty custom site schema to null', function () {
+    Blink::flush();
+
+    $defaults = Seo::find('site::defaults')->in('english');
+    $defaults->set('site_json_ld_type', 'custom');
+    $defaults->set('site_json_ld', '');
+    $defaults->save();
+
+    $cascade = ContentCascade::from($this->entry);
+
+    expect($cascade->siteSchema())->toBeNull();
+});
+
+it('leaves token-free custom site schema unchanged', function () {
+    Blink::flush();
+
+    $defaults = Seo::find('site::defaults')->in('english');
+    $defaults->set('site_json_ld_type', 'custom');
+    $defaults->set('site_json_ld', '{"@type": "Organization"}');
+    $defaults->save();
+
+    $cascade = ContentCascade::from($this->entry);
+
+    expect($cascade->siteSchema())->toBe('{"@type": "Organization"}');
 });

--- a/tests/Cascades/ContextViewCascadeTest.php
+++ b/tests/Cascades/ContextViewCascadeTest.php
@@ -6,6 +6,7 @@ use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Site;
 use Statamic\Facades\Taxonomy;
+use Statamic\Fields\LabeledValue;
 use Statamic\Tags\Context;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 
@@ -198,4 +199,18 @@ it('returns default title when context has a title', function () {
 
     // For non-taxonomy, non-404 contexts, the title comes from cascade or context title.
     expect($cascade->title())->toContain('Custom Page');
+});
+
+it('resolves tokens in custom site schema on a custom route', function () {
+    $context = new Context(collect([
+        'title' => 'Custom Page',
+        'current_url' => 'https://example.com/custom',
+        'site' => Site::get('english'),
+    ]));
+
+    $cascade = ContextViewCascade::from($context);
+    $cascade->set('site_json_ld_type', new LabeledValue('custom', 'Custom'));
+    $cascade->set('site_json_ld', '{"name": "{{ title }}", "url": "{{ current_url }}"}');
+
+    expect($cascade->siteSchema())->toBe('{"name": "Custom Page", "url": "https://example.com/custom"}');
 });

--- a/tests/Cascades/ContextViewCascadeTest.php
+++ b/tests/Cascades/ContextViewCascadeTest.php
@@ -4,6 +4,7 @@ use Aerni\AdvancedSeo\Cascades\ContextViewCascade;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
+use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Site;
 use Statamic\Facades\Taxonomy;
 use Statamic\Fields\LabeledValue;
@@ -201,7 +202,13 @@ it('returns default title when context has a title', function () {
     expect($cascade->title())->toContain('Custom Page');
 });
 
-it('resolves tokens in custom site schema on a custom route', function () {
+it('resolves tokens in custom site schema against the view context', function () {
+    config()->set('app.name', 'Acme Inc');
+
+    $set = GlobalSet::make('company')->sites(['english']);
+    $set->save();
+    $set->in('english')->data(['tagline' => 'We build things'])->save();
+
     $context = new Context(collect([
         'title' => 'Custom Page',
         'current_url' => 'https://example.com/custom',
@@ -210,7 +217,7 @@ it('resolves tokens in custom site schema on a custom route', function () {
 
     $cascade = ContextViewCascade::from($context);
     $cascade->set('site_json_ld_type', new LabeledValue('custom', 'Custom'));
-    $cascade->set('site_json_ld', '{"name": "{{ title }}", "url": "{{ current_url }}"}');
+    $cascade->set('site_json_ld', '{"name": "{{ title }}", "url": "{{ current_url }}", "publisher": "{{ config:app:name }}", "slogan": "{{ company:tagline }}"}');
 
-    expect($cascade->siteSchema())->toBe('{"name": "Custom Page", "url": "https://example.com/custom"}');
+    expect($cascade->siteSchema())->toBe('{"name": "Custom Page", "url": "https://example.com/custom", "publisher": "Acme Inc", "slogan": "We build things"}');
 });


### PR DESCRIPTION
Custom JSON-LD now resolves Antlers everywhere it's used, the site SEO defaults and the content/entry level, with full page context: page fields, site SEO defaults, globals, config, plus tags and modifiers. Previously the site-level custom JSON-LD left `{{ }}` tokens unresolved entirely, and the content-level field had no access to globals or config.