### PR TITLE
Patch vulnerable npm lockfile dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "statamic-advanced-seo",
             "dependencies": {
                 "@tiptap/core": "^3.0.0",
                 "@tiptap/extension-document": "^3.0.0",
@@ -2044,9 +2043,9 @@
             }
         },
         "node_modules/linkify-it": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-            "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+            "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
             "funding": [
                 {
                     "type": "github",
@@ -2105,9 +2104,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.12",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",
@@ -2148,9 +2147,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+            "version": "8.5.26",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2167,7 +2166,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.17",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },


### PR DESCRIPTION
## Summary
- Bump transitive npm packages in `package-lock.json` to clear the 5 open Dependabot alerts.
- `nanoid` 3.3.12 → 3.3.18 (GHSA-2v37-7h3g-55p8, GHSA-28wg-ghj8-5hjv)
- `postcss` 8.5.15 → 8.5.26 (GHSA-r28c-9q8g-f849, GHSA-fxqj-rqcc-2cmp)
- `linkify-it` 5.0.1 → 5.0.2 (GHSA-v245-v573-v5vm)

These are lockfile-only updates of existing `^` ranges. `package.json` is unchanged. `npm audit` reports 0 vulnerabilities after the bump.

## Test plan
- [ ] Confirm Dependabot alerts 82, 83, 84, 86, and 87 close after merge
- [ ] `npm run build` still succeeds


Made with [Cursor](https://cursor.com)