### PR TITLE
Fix redirect errors CP crash under concurrent 404 recording

### DIFF
--- a/src/Stache/Repositories/RedirectErrorRepository.php
+++ b/src/Stache/Repositories/RedirectErrorRepository.php
@@ -60,9 +60,15 @@ class RedirectErrorRepository implements Contract
         $this->store->delete($error);
     }
 
+    /**
+     * Concurrent writers race on the Stache path index: one process can delete a
+     * file while another writes a stale index that still lists it (or the reverse),
+     * leaving ghost or orphan error records. One global lock prevents that; locking
+     * per url is not enough because different urls still create and evict in parallel.
+     */
     public function record(string $url, string $site): void
     {
-        Cache::lock("advanced-seo::redirect-error:{$site}:{$url}", 10)->block(5, function () use ($url, $site) {
+        Cache::lock('advanced-seo::redirect-error', 10)->block(5, function () use ($url, $site) {
             $error = $this->findByUrl($url, $site);
 
             if (! $error) {

--- a/tests/Redirects/RecordErrorTest.php
+++ b/tests/Redirects/RecordErrorTest.php
@@ -4,6 +4,7 @@ use Aerni\AdvancedSeo\Facades\Redirect;
 use Aerni\AdvancedSeo\Jobs\RecordRedirectErrorJob;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 
 uses(PreventsSavingStacheItemsToDisk::class);
@@ -63,6 +64,17 @@ it('does not evict when max_records is false', function () {
     Redirect::errors()->record('/c', 'default');
 
     expect(Redirect::errors()->all())->toHaveCount(3);
+});
+
+it('records different urls behind the same global lock', function () {
+    Cache::spy();
+
+    Redirect::errors()->record('/one', 'default');
+    Redirect::errors()->record('/two', 'default');
+
+    Cache::shouldHaveReceived('lock')
+        ->with('advanced-seo::redirect-error', 10)
+        ->twice();
 });
 
 it('records via the queued job', function () {


### PR DESCRIPTION
When many 404s were recorded at once, concurrent creates and capacity evictions raced on the Stache path index. That left ghost error records (index entry without a file) which made the redirect errors CP crash on a null URL. File-driver recording now uses one global lock so those writes can no longer run in parallel, with a regression test that different URLs share the same lock key.