### PR TITLE
Ignore nested WordPress probes in the redirect error inbox

### DIFF
--- a/config/advanced-seo.php
+++ b/config/advanced-seo.php
@@ -508,9 +508,9 @@ return [
             */
 
             'ignore' => [
-                '#\.php$#',        // PHP probes: wp-login.php, xmlrpc.php, admin-ajax.php
-                '#^/wp-admin#',    // WordPress admin
-                '#^/\.(env|git)#', // Secrets and repo probes
+                '#\.php$#',                              // PHP probes: wp-login.php, xmlrpc.php, admin-ajax.php
+                '#/wp-(admin|includes|content)(/|$)#',   // WordPress probes at any depth
+                '#^/\.(env|git)#',                       // Secrets and repo probes
             ],
 
         ],

--- a/src/UpdateScripts/stubs/redirects_config.php.stub
+++ b/src/UpdateScripts/stubs/redirects_config.php.stub
@@ -142,9 +142,9 @@
             */
 
             'ignore' => [
-                '#\.php$#',        // PHP probes: wp-login.php, xmlrpc.php, admin-ajax.php
-                '#^/wp-admin#',    // WordPress admin
-                '#^/\.(env|git)#', // Secrets and repo probes
+                '#\.php$#',                              // PHP probes: wp-login.php, xmlrpc.php, admin-ajax.php
+                '#/wp-(admin|includes|content)(/|$)#',   // WordPress probes at any depth
+                '#^/\.(env|git)#',                       // Secrets and repo probes
             ],
 
         ],

--- a/tests/Redirects/RedirectHandlerTest.php
+++ b/tests/Redirects/RedirectHandlerTest.php
@@ -182,3 +182,12 @@ it('does not record an error for an ignored path', function () {
 
     Queue::assertNotPushed(RecordRedirectErrorJob::class);
 });
+
+it('does not record an error for nested wordpress probes', function () {
+    config(['advanced-seo.redirects.errors.enabled' => true]);
+    Queue::fake();
+
+    $this->get('/blog/wp-includes/wlwmanifest.xml')->assertNotFound();
+
+    Queue::assertNotPushed(RecordRedirectErrorJob::class);
+});

--- a/tests/Redirects/RedirectPatternMatcherTest.php
+++ b/tests/Redirects/RedirectPatternMatcherTest.php
@@ -60,8 +60,9 @@ it('matches a wildcard source within a single segment only', function () {
 it('matches a regex source at any depth', function () {
     expect(RedirectPatternMatcher::matches('#\.php$#', '/wp-login.php'))->toBeTrue()
         ->and(RedirectPatternMatcher::matches('#\.php$#', '/nested/path/admin-ajax.php'))->toBeTrue()
-        ->and(RedirectPatternMatcher::matches('#^/wp-admin#', '/wp-admin/options.php'))->toBeTrue()
-        ->and(RedirectPatternMatcher::matches('#^/wp-admin#', '/admin'))->toBeFalse();
+        ->and(RedirectPatternMatcher::matches('#/wp-(admin|includes|content)(/|$)#', '/wp-admin/options.php'))->toBeTrue()
+        ->and(RedirectPatternMatcher::matches('#/wp-(admin|includes|content)(/|$)#', '/blog/wp-includes/wlwmanifest.xml'))->toBeTrue()
+        ->and(RedirectPatternMatcher::matches('#/wp-(admin|includes|content)(/|$)#', '/admin'))->toBeFalse();
 });
 
 it('substitutes capture placeholders into the destination', function () {

--- a/tests/UpdateScripts/AddRedirectsTest.php
+++ b/tests/UpdateScripts/AddRedirectsTest.php
@@ -53,7 +53,7 @@ it('adds the complete redirects configuration to the published config', function
             'max_records' => 1000,
             'ignore' => [
                 '#\\.php$#',
-                '#^/wp-admin#',
+                '#/wp-(admin|includes|content)(/|$)#',
                 '#^/\\.(env|git)#',
             ],
         ],


### PR DESCRIPTION
The previous `/wp-admin` pattern only matched at the site root, so scanner hits like `/blog/wp-includes/wlwmanifest.xml` still filled the list. The default ignore pattern now covers `wp-admin`, `wp-includes`, and `wp-content` at any depth.