### PR TITLE
Speed up redirect error clearing with bulk deletes

### DIFF
--- a/src/Actions/Statamic/DeleteRedirectError.php
+++ b/src/Actions/Statamic/DeleteRedirectError.php
@@ -4,6 +4,7 @@ namespace Aerni\AdvancedSeo\Actions\Statamic;
 
 use Aerni\AdvancedSeo\Contracts\Redirect;
 use Aerni\AdvancedSeo\Contracts\RedirectError;
+use Aerni\AdvancedSeo\Facades\Redirect as RedirectFacade;
 use Statamic\Actions\Action;
 
 class DeleteRedirectError extends Action
@@ -44,6 +45,8 @@ class DeleteRedirectError extends Action
 
     public function run($items, $values)
     {
-        $items->each->delete();
+        $ids = $items->map->id()->all();
+
+        RedirectFacade::errors()->deleteByIds($ids);
     }
 }

--- a/src/Commands/PruneRedirectErrors.php
+++ b/src/Commands/PruneRedirectErrors.php
@@ -35,10 +35,13 @@ class PruneRedirectErrors extends Command
 
         $cutoff = Carbon::now()->subDays($days)->timestamp;
 
-        Redirect::errors()->query()
+        $ids = Redirect::errors()->query()
             ->where('last_seen_at', '<', $cutoff)
             ->get()
-            ->each->delete();
+            ->map->id()
+            ->all();
+
+        Redirect::errors()->deleteByIds($ids);
     }
 
     protected function deleteHandledRecords(): void
@@ -60,11 +63,14 @@ class PruneRedirectErrors extends Command
             return;
         }
 
-        Redirect::errors()->query()
+        $ids = Redirect::errors()->query()
             ->orderBy('count')
             ->orderBy('last_seen_at')
             ->limit($count - $max)
             ->get()
-            ->each->delete();
+            ->map->id()
+            ->all();
+
+        Redirect::errors()->deleteByIds($ids);
     }
 }

--- a/src/Contracts/RedirectErrorRepository.php
+++ b/src/Contracts/RedirectErrorRepository.php
@@ -20,6 +20,10 @@ interface RedirectErrorRepository
 
     public function delete(RedirectError $error): void;
 
+    public function deleteBySites(array $sites): void;
+
+    public function deleteByIds(array $ids): void;
+
     public function record(string $url, string $site): void;
 
     public function maxRecords(): ?int;

--- a/src/Eloquent/RedirectErrorQueryBuilder.php
+++ b/src/Eloquent/RedirectErrorQueryBuilder.php
@@ -2,12 +2,13 @@
 
 namespace Aerni\AdvancedSeo\Eloquent;
 
+use Aerni\AdvancedSeo\Contracts\RedirectError;
 use Aerni\AdvancedSeo\Contracts\RedirectErrorQueryBuilder as Contract;
 
 class RedirectErrorQueryBuilder extends QueryBuilder implements Contract
 {
     protected function toItem($model)
     {
-        return RedirectError::fromModel($model);
+        return app(RedirectError::class)::fromModel($model);
     }
 }

--- a/src/Eloquent/RedirectErrorRepository.php
+++ b/src/Eloquent/RedirectErrorRepository.php
@@ -22,7 +22,7 @@ class RedirectErrorRepository implements Contract
 
     public function find(string $id): ?RedirectError
     {
-        $model = app('statamic.eloquent.redirect_error.model')::query()->find($id);
+        $model = $this->model()::query()->find($id);
 
         return $model ? app(RedirectError::class)::fromModel($model) : null;
     }
@@ -31,7 +31,7 @@ class RedirectErrorRepository implements Contract
     {
         $site ??= Site::default()->handle();
 
-        $model = app('statamic.eloquent.redirect_error.model')::query()
+        $model = $this->model()::query()
             ->where('url', $url)
             ->where('site', $site)
             ->first();
@@ -41,14 +41,13 @@ class RedirectErrorRepository implements Contract
 
     public function all(): Collection
     {
-        return app('statamic.eloquent.redirect_error.model')::all()
-            ->map(fn ($model) => app(RedirectError::class)::fromModel($model));
+        return $this->query()->get();
     }
 
     public function query(): RedirectErrorQueryBuilder
     {
         return app(RedirectErrorQueryBuilder::class, [
-            'builder' => app('statamic.eloquent.redirect_error.model')::query(),
+            'builder' => $this->model()::query(),
         ]);
     }
 
@@ -66,14 +65,24 @@ class RedirectErrorRepository implements Contract
         $error->model()->delete();
     }
 
+    public function deleteBySites(array $sites): void
+    {
+        $this->model()::query()->whereIn('site', $sites)->delete();
+    }
+
+    public function deleteByIds(array $ids): void
+    {
+        $this->model()::query()->whereIn('id', $ids)->delete();
+    }
+
     public function record(string $url, string $site): void
     {
-        $model = app('statamic.eloquent.redirect_error.model');
+        $model = $this->model();
 
         $now = now()->timestamp;
 
         if (! $model::query()->where('url', $url)->where('site', $site)->exists()) {
-            $this->ensureCapacityForError();
+            $this->makeRoomForNewRecord();
 
             try {
                 $model::create([
@@ -97,7 +106,10 @@ class RedirectErrorRepository implements Contract
             ->increment('count', 1, ['last_seen_at' => $now]);
     }
 
-    protected function ensureCapacityForError(): void
+    /**
+     * Evict lowest-value errors when at the record cap so a new one can be stored.
+     */
+    protected function makeRoomForNewRecord(): void
     {
         $max = $this->maxRecords();
 
@@ -105,7 +117,7 @@ class RedirectErrorRepository implements Contract
             return;
         }
 
-        $model = app('statamic.eloquent.redirect_error.model');
+        $model = $this->model();
 
         $count = $model::query()->count();
 
@@ -117,9 +129,15 @@ class RedirectErrorRepository implements Contract
             ->orderBy('count')
             ->orderBy('last_seen_at')
             ->limit($count - $max + 1)
-            ->pluck('id');
+            ->pluck('id')
+            ->all();
 
-        $model::query()->whereIn('id', $ids)->delete();
+        $this->deleteByIds($ids);
+    }
+
+    protected function model(): string
+    {
+        return app('statamic.eloquent.redirect_error.model')::class;
     }
 
     public static function bindings(): array

--- a/src/Eloquent/RedirectErrorRepository.php
+++ b/src/Eloquent/RedirectErrorRepository.php
@@ -72,7 +72,9 @@ class RedirectErrorRepository implements Contract
 
     public function deleteByIds(array $ids): void
     {
-        $this->model()::query()->whereIn('id', $ids)->delete();
+        foreach (array_chunk($ids, 500) as $chunk) {
+            $this->model()::query()->whereIn('id', $chunk)->delete();
+        }
     }
 
     public function record(string $url, string $site): void

--- a/src/Eloquent/RedirectHitQueryBuilder.php
+++ b/src/Eloquent/RedirectHitQueryBuilder.php
@@ -2,12 +2,13 @@
 
 namespace Aerni\AdvancedSeo\Eloquent;
 
+use Aerni\AdvancedSeo\Contracts\RedirectHit;
 use Aerni\AdvancedSeo\Contracts\RedirectHitQueryBuilder as Contract;
 
 class RedirectHitQueryBuilder extends QueryBuilder implements Contract
 {
     protected function toItem($model)
     {
-        return RedirectHit::fromModel($model);
+        return app(RedirectHit::class)::fromModel($model);
     }
 }

--- a/src/Eloquent/RedirectQueryBuilder.php
+++ b/src/Eloquent/RedirectQueryBuilder.php
@@ -3,6 +3,7 @@
 namespace Aerni\AdvancedSeo\Eloquent;
 
 use Aerni\AdvancedSeo\Concerns\QueriesRedirectSources;
+use Aerni\AdvancedSeo\Contracts\Redirect;
 use Aerni\AdvancedSeo\Contracts\RedirectQueryBuilder as Contract;
 
 class RedirectQueryBuilder extends QueryBuilder implements Contract
@@ -11,7 +12,7 @@ class RedirectQueryBuilder extends QueryBuilder implements Contract
 
     protected function toItem($model)
     {
-        return Redirect::fromModel($model);
+        return app(Redirect::class)::fromModel($model);
     }
 
     public function orderBy($column, $direction = 'asc')

--- a/src/Http/Controllers/Cp/RedirectErrorController.php
+++ b/src/Http/Controllers/Cp/RedirectErrorController.php
@@ -105,9 +105,8 @@ class RedirectErrorController extends CpController
 
         $this->authorize('manage', Redirect::class);
 
-        RedirectFacade::errors()->query()
-            ->whereIn('site', Site::authorized()->map->handle()->all())
-            ->get()
-            ->each->delete();
+        RedirectFacade::errors()->deleteBySites(
+            Site::authorized()->map->handle()->all()
+        );
     }
 }

--- a/src/Redirects/RedirectErrorInbox.php
+++ b/src/Redirects/RedirectErrorInbox.php
@@ -10,30 +10,38 @@ class RedirectErrorInbox
 {
     public function deleteErrorsHandledBy(Redirect $redirect): void
     {
-        if (! $redirect->enabled()) {
-            return;
-        }
+        RedirectFacade::errors()->deleteByIds($this->errorsHandledBy($redirect));
+    }
 
-        if (! $redirect->resolves()) {
-            return;
-        }
-
-        $ids = RedirectFacade::errors()->query()
-            ->where('site', $redirect->site())
+    public function deleteHandledErrors(): void
+    {
+        $ids = RedirectFacade::query()
+            ->where('enabled', true)
+            ->whereIn('site', Site::all()->map->handle()->all())
             ->get()
-            ->filter(fn ($error) => RedirectPatternMatcher::matches($redirect->source(), $error->url()))
-            ->map->id()
+            ->flatMap(fn ($redirect) => $this->errorsHandledBy($redirect))
+            ->unique()
+            ->values()
             ->all();
 
         RedirectFacade::errors()->deleteByIds($ids);
     }
 
-    public function deleteHandledErrors(): void
+    protected function errorsHandledBy(Redirect $redirect): array
     {
-        RedirectFacade::query()
-            ->where('enabled', true)
-            ->whereIn('site', Site::all()->map->handle()->all())
+        if (! $redirect->enabled()) {
+            return [];
+        }
+
+        if (! $redirect->resolves()) {
+            return [];
+        }
+
+        return RedirectFacade::errors()->query()
+            ->where('site', $redirect->site())
             ->get()
-            ->each(fn ($redirect) => $this->deleteErrorsHandledBy($redirect));
+            ->filter(fn ($error) => RedirectPatternMatcher::matches($redirect->source(), $error->url()))
+            ->map->id()
+            ->all();
     }
 }

--- a/src/Redirects/RedirectErrorInbox.php
+++ b/src/Redirects/RedirectErrorInbox.php
@@ -18,11 +18,14 @@ class RedirectErrorInbox
             return;
         }
 
-        RedirectFacade::errors()->query()
+        $ids = RedirectFacade::errors()->query()
             ->where('site', $redirect->site())
             ->get()
             ->filter(fn ($error) => RedirectPatternMatcher::matches($redirect->source(), $error->url()))
-            ->each->delete();
+            ->map->id()
+            ->all();
+
+        RedirectFacade::errors()->deleteByIds($ids);
     }
 
     public function deleteHandledErrors(): void

--- a/src/Stache/Repositories/RedirectErrorRepository.php
+++ b/src/Stache/Repositories/RedirectErrorRepository.php
@@ -6,17 +6,17 @@ use Aerni\AdvancedSeo\Concerns\HasRedirectErrorLimits;
 use Aerni\AdvancedSeo\Contracts\RedirectError;
 use Aerni\AdvancedSeo\Contracts\RedirectErrorQueryBuilder;
 use Aerni\AdvancedSeo\Contracts\RedirectErrorRepository as Contract;
+use Aerni\AdvancedSeo\Stache\Stores\RedirectErrorsStore;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Statamic\Facades\Site;
 use Statamic\Stache\Stache;
-use Statamic\Stache\Stores\Store;
 
 class RedirectErrorRepository implements Contract
 {
     use HasRedirectErrorLimits;
 
-    protected Store $store;
+    protected RedirectErrorsStore $store;
 
     public function __construct(protected Stache $stache)
     {
@@ -60,6 +60,23 @@ class RedirectErrorRepository implements Contract
         $this->store->delete($error);
     }
 
+    public function deleteBySites(array $sites): void
+    {
+        $this->lock(function () use ($sites) {
+            $keys = $this->store->index('site')->load()->items()
+                ->filter(fn ($site) => in_array($site, $sites, true))
+                ->keys()
+                ->all();
+
+            $this->store->deleteKeys($keys);
+        });
+    }
+
+    public function deleteByIds(array $ids): void
+    {
+        $this->lock(fn () => $this->store->deleteKeys($ids));
+    }
+
     /**
      * Concurrent writers race on the Stache path index: one process can delete a
      * file while another writes a stale index that still lists it (or the reverse),
@@ -68,11 +85,11 @@ class RedirectErrorRepository implements Contract
      */
     public function record(string $url, string $site): void
     {
-        Cache::lock('advanced-seo::redirect-error', 10)->block(5, function () use ($url, $site) {
+        $this->lock(function () use ($url, $site) {
             $error = $this->findByUrl($url, $site);
 
             if (! $error) {
-                $this->ensureCapacityForError();
+                $this->makeRoomForNewRecord();
 
                 $error = $this->make()->url($url)->site($site)->firstSeenAt(now()->timestamp);
             }
@@ -84,7 +101,11 @@ class RedirectErrorRepository implements Contract
         });
     }
 
-    protected function ensureCapacityForError(): void
+    /**
+     * Evict lowest-value errors when at the record cap so a new one can be stored.
+     * Must be called while holding the redirect-error lock.
+     */
+    protected function makeRoomForNewRecord(): void
     {
         $max = $this->maxRecords();
 
@@ -98,12 +119,24 @@ class RedirectErrorRepository implements Contract
             return;
         }
 
-        $this->query()
+        $ids = $this->query()
             ->orderBy('count')
             ->orderBy('last_seen_at')
             ->limit($count - $max + 1)
             ->get()
-            ->each->delete();
+            ->map->id()
+            ->all();
+
+        /**
+         * Already holding the lock from record(). Call the store directly —
+         * deleteByIds() would try to acquire the same lock again and deadlock.
+         */
+        $this->store->deleteKeys($ids);
+    }
+
+    protected function lock(callable $callback): mixed
+    {
+        return Cache::lock('advanced-seo::redirect-error', 10)->block(5, $callback);
     }
 
     public static function bindings(): array

--- a/src/Stache/Repositories/RedirectErrorRepository.php
+++ b/src/Stache/Repositories/RedirectErrorRepository.php
@@ -136,7 +136,7 @@ class RedirectErrorRepository implements Contract
 
     protected function lock(callable $callback): mixed
     {
-        return Cache::lock('advanced-seo::redirect-error', 10)->block(5, $callback);
+        return Cache::lock('advanced-seo::redirect-error', 60)->block(5, $callback);
     }
 
     public static function bindings(): array

--- a/src/Stache/Repositories/RedirectErrorRepository.php
+++ b/src/Stache/Repositories/RedirectErrorRepository.php
@@ -57,7 +57,7 @@ class RedirectErrorRepository implements Contract
 
     public function delete(RedirectError $error): void
     {
-        $this->store->delete($error);
+        $this->lock(fn () => $this->store->delete($error));
     }
 
     public function deleteBySites(array $sites): void

--- a/src/Stache/Stores/RedirectErrorsStore.php
+++ b/src/Stache/Stores/RedirectErrorsStore.php
@@ -4,6 +4,7 @@ namespace Aerni\AdvancedSeo\Stache\Stores;
 
 use Aerni\AdvancedSeo\Contracts\RedirectError;
 use Aerni\AdvancedSeo\Facades\Redirect;
+use Illuminate\Support\Facades\File;
 use Statamic\Facades\Path;
 use Statamic\Facades\YAML;
 use Statamic\Stache\Stores\BasicStore;
@@ -41,6 +42,23 @@ class RedirectErrorsStore extends BasicStore
             ->count(Arr::get($data, 'count', 0))
             ->firstSeenAt(Arr::get($data, 'first_seen_at'))
             ->lastSeenAt(Arr::get($data, 'last_seen_at'));
+    }
+
+    public function deleteKeys(array $keys): void
+    {
+        if ($keys === []) {
+            return;
+        }
+
+        $files = collect($keys)
+            ->map(fn ($key) => $this->getPath($key))
+            ->filter()
+            ->values()
+            ->all();
+
+        File::delete($files);
+
+        $this->clear();
     }
 
     protected function storeIndexes(): array

--- a/tests/Eloquent/RedirectErrorRepositoryTest.php
+++ b/tests/Eloquent/RedirectErrorRepositoryTest.php
@@ -3,8 +3,54 @@
 use Aerni\AdvancedSeo\Contracts\RedirectError as RedirectErrorContract;
 use Aerni\AdvancedSeo\Facades\Redirect;
 use Aerni\AdvancedSeo\Tests\Concerns\UseEloquentDriver;
+use Statamic\Facades\Site;
 
 uses(UseEloquentDriver::class);
+
+it('bulk deletes errors for the given sites via eloquent', function () {
+    Site::setSites([
+        'default' => ['name' => 'Default', 'url' => '/', 'locale' => 'en'],
+        'fr' => ['name' => 'French', 'url' => '/fr/', 'locale' => 'fr'],
+    ]);
+
+    Redirect::errors()->make()->url('/a')->site('default')->count(1)->save();
+    Redirect::errors()->make()->url('/b')->site('default')->count(1)->save();
+    Redirect::errors()->make()->url('/c')->site('fr')->count(1)->save();
+
+    Redirect::errors()->deleteBySites(['default']);
+
+    $urls = Redirect::errors()->all()->map->url();
+
+    expect($urls)->not->toContain('/a')->not->toContain('/b')->toContain('/c');
+});
+
+it('no-ops when deleteBySites receives an empty site list via eloquent', function () {
+    Redirect::errors()->make()->url('/a')->site('default')->count(1)->save();
+
+    Redirect::errors()->deleteBySites([]);
+
+    expect(Redirect::errors()->all())->toHaveCount(1);
+});
+
+it('bulk deletes errors by id via eloquent', function () {
+    $a = tap(Redirect::errors()->make()->url('/a')->site('default')->count(1))->save();
+    $b = tap(Redirect::errors()->make()->url('/b')->site('default')->count(1))->save();
+    $c = tap(Redirect::errors()->make()->url('/c')->site('default')->count(1))->save();
+
+    Redirect::errors()->deleteByIds([$a->id(), $c->id()]);
+
+    $urls = Redirect::errors()->all()->map->url();
+
+    expect($urls)->not->toContain('/a')->toContain('/b')->not->toContain('/c');
+});
+
+it('no-ops when deleteByIds receives an empty id list via eloquent', function () {
+    Redirect::errors()->make()->url('/a')->site('default')->count(1)->save();
+
+    Redirect::errors()->deleteByIds([]);
+
+    expect(Redirect::errors()->all())->toHaveCount(1);
+});
 
 it('saves and finds an error via eloquent', function () {
     Redirect::errors()->make()->url('/missing')->site('default')->count(2)->save();

--- a/tests/Eloquent/RedirectErrorRepositoryTest.php
+++ b/tests/Eloquent/RedirectErrorRepositoryTest.php
@@ -52,6 +52,19 @@ it('no-ops when deleteByIds receives an empty id list via eloquent', function ()
     expect(Redirect::errors()->all())->toHaveCount(1);
 });
 
+it('bulk deletes more ids than one whereIn chunk via eloquent', function () {
+    $ids = collect(range(1, 501))->map(function ($i) {
+        $error = Redirect::errors()->make()->url("/missing-{$i}")->site('default')->count(1);
+        $error->save();
+
+        return $error->id();
+    })->all();
+
+    Redirect::errors()->deleteByIds($ids);
+
+    expect(Redirect::errors()->all())->toHaveCount(0);
+});
+
 it('saves and finds an error via eloquent', function () {
     Redirect::errors()->make()->url('/missing')->site('default')->count(2)->save();
 

--- a/tests/Redirects/RecordErrorTest.php
+++ b/tests/Redirects/RecordErrorTest.php
@@ -73,7 +73,7 @@ it('records different urls behind the same global lock', function () {
     Redirect::errors()->record('/two', 'default');
 
     Cache::shouldHaveReceived('lock')
-        ->with('advanced-seo::redirect-error', 10)
+        ->with('advanced-seo::redirect-error', 60)
         ->twice();
 });
 

--- a/tests/Stache/Repositories/RedirectErrorRepositoryTest.php
+++ b/tests/Stache/Repositories/RedirectErrorRepositoryTest.php
@@ -1,9 +1,55 @@
 <?php
 
 use Aerni\AdvancedSeo\Facades\Redirect;
+use Statamic\Facades\Site;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 
 uses(PreventsSavingStacheItemsToDisk::class);
+
+it('bulk deletes errors for the given sites', function () {
+    Site::setSites([
+        'default' => ['name' => 'Default', 'url' => '/', 'locale' => 'en'],
+        'fr' => ['name' => 'French', 'url' => '/fr/', 'locale' => 'fr'],
+    ]);
+
+    Redirect::errors()->make()->url('/a')->site('default')->count(1)->save();
+    Redirect::errors()->make()->url('/b')->site('default')->count(1)->save();
+    Redirect::errors()->make()->url('/c')->site('fr')->count(1)->save();
+
+    Redirect::errors()->deleteBySites(['default']);
+
+    $urls = Redirect::errors()->all()->map->url();
+
+    expect($urls)->not->toContain('/a')->not->toContain('/b')->toContain('/c');
+});
+
+it('no-ops when deleteBySites receives an empty site list', function () {
+    Redirect::errors()->make()->url('/a')->site('default')->count(1)->save();
+
+    Redirect::errors()->deleteBySites([]);
+
+    expect(Redirect::errors()->all())->toHaveCount(1);
+});
+
+it('bulk deletes errors by id', function () {
+    $a = tap(Redirect::errors()->make()->url('/a')->site('default')->count(1))->save();
+    $b = tap(Redirect::errors()->make()->url('/b')->site('default')->count(1))->save();
+    $c = tap(Redirect::errors()->make()->url('/c')->site('default')->count(1))->save();
+
+    Redirect::errors()->deleteByIds([$a->id(), $c->id()]);
+
+    $urls = Redirect::errors()->all()->map->url();
+
+    expect($urls)->not->toContain('/a')->toContain('/b')->not->toContain('/c');
+});
+
+it('no-ops when deleteByIds receives an empty id list', function () {
+    Redirect::errors()->make()->url('/a')->site('default')->count(1)->save();
+
+    Redirect::errors()->deleteByIds([]);
+
+    expect(Redirect::errors()->all())->toHaveCount(1);
+});
 
 it('returns the configured max records', function () {
     config(['advanced-seo.redirects.errors.max_records' => 50]);


### PR DESCRIPTION
Clear All and related cleanup paths were deleting redirect errors one by one, which made the CP painfully slow on large inboxes (especially with the file driver).

They now go through `deleteBySites` / `deleteByIds`, with Stache bulk file removal plus a full store clear, and Eloquent deletes chunked to stay under query parameter limits.

Handled-error prune is batched into a single delete so the Stache store is not rebuilt once per redirect. The redirect-error lock lease is extended for long clears, and single-item Stache deletes take the same lock as recording.

Eloquent redirect query builders also resolve domain objects via contract bindings like the repositories.