### PR TITLE
Skip orphaned SEO set YAML for deleted collections and taxonomies

### DIFF
--- a/src/Concerns/ParsesSeoSetPath.php
+++ b/src/Concerns/ParsesSeoSetPath.php
@@ -2,6 +2,8 @@
 
 namespace Aerni\AdvancedSeo\Concerns;
 
+use Aerni\AdvancedSeo\Facades\Seo;
+
 trait ParsesSeoSetPath
 {
     protected function parseRelativePath(string $relativePath): array
@@ -16,7 +18,6 @@ trait ParsesSeoSetPath
     {
         ['type' => $type, 'handle' => $handle] = $this->parseRelativePath($relativePath);
 
-        return in_array($type, ['site', 'collections', 'taxonomies'])
-            && ($type !== 'site' || $handle === 'defaults');
+        return Seo::find("{$type}::{$handle}") !== null;
     }
 }

--- a/tests/Stache/Stores/SeoSetConfigsStoreTest.php
+++ b/tests/Stache/Stores/SeoSetConfigsStoreTest.php
@@ -45,14 +45,10 @@ it('filters yaml files one level deep', function (): void {
     $this->files->put(tempPath('collections/ignored.txt'), '');
     $this->files->put(tempPath('collections/en/ignored.yaml'), '');
 
-    $this->files->ensureDirectoryExists(tempPath('taxonomies'));
-    $this->files->put(tempPath('taxonomies/categories.yaml'), '');
-
     $files = Traverser::filter([$this->store, 'getItemFilter'])->traverse($this->store);
 
     expect($files->keys()->all())->toMatchArray([
         tempPath('collections/articles.yaml'),
-        tempPath('taxonomies/categories.yaml'),
     ]);
 
     /* Sanity check. Make sure the files are there but were not included. */
@@ -66,6 +62,20 @@ it('filters out unknown types', function (): void {
     $this->files->ensureDirectoryExists(tempPath('unknown'));
     $this->files->put(tempPath('collections/articles.yaml'), '');
     $this->files->put(tempPath('unknown/articles.yaml'), '');
+
+    $files = Traverser::filter([$this->store, 'getItemFilter'])->traverse($this->store);
+
+    expect($files->keys()->all())->toMatchArray([
+        tempPath('collections/articles.yaml'),
+    ]);
+});
+
+it('filters out orphaned collection and taxonomy yaml', function (): void {
+    $this->files->ensureDirectoryExists(tempPath('collections'));
+    $this->files->ensureDirectoryExists(tempPath('taxonomies'));
+    $this->files->put(tempPath('collections/articles.yaml'), '');
+    $this->files->put(tempPath('collections/deleted.yaml'), '');
+    $this->files->put(tempPath('taxonomies/categories.yaml'), '');
 
     $files = Traverser::filter([$this->store, 'getItemFilter'])->traverse($this->store);
 

--- a/tests/Stache/Stores/SeoSetLocalizationsStoreTest.php
+++ b/tests/Stache/Stores/SeoSetLocalizationsStoreTest.php
@@ -75,6 +75,20 @@ it('filters out unknown types', function (): void {
     ]);
 });
 
+it('filters out orphaned collection and taxonomy yaml', function (): void {
+    $this->files->ensureDirectoryExists(tempPath('collections/english'));
+    $this->files->ensureDirectoryExists(tempPath('taxonomies/english'));
+    $this->files->put(tempPath('collections/english/articles.yaml'), '');
+    $this->files->put(tempPath('collections/english/deleted.yaml'), '');
+    $this->files->put(tempPath('taxonomies/english/categories.yaml'), '');
+
+    $files = Traverser::filter([$this->store, 'getItemFilter'])->traverse($this->store);
+
+    expect($files->keys()->all())->toMatchArray([
+        tempPath('collections/english/articles.yaml'),
+    ]);
+});
+
 it('filters out old site set handles', function (): void {
     $this->files->ensureDirectoryExists(tempPath('site/english'));
     $this->files->put(tempPath('site/english/defaults.yaml'), '');


### PR DESCRIPTION
Stache could still load SEO config/localization YAML for collections or taxonomies that no longer exist—leftovers from incomplete delete cleanup, manual file handling, and similar cases. That led to a TypeError when domain code expected a real SEO set. `isValidSeoSet()` now requires `Seo::find()`, so orphaned YAML stays on disk but is ignored. Cleaning up those files on delete is handled separately.