### PR TITLE
Ask before migrating Eloquent data during install

### DIFF
--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -320,13 +320,23 @@ class Install extends Command
             );
         }
 
+        if (! confirm(
+            label: 'Would you like to switch to Eloquent and migrate your existing SEO data now?',
+            default: false,
+            hint: 'You can do this later with `php artisan seo:switch-to-eloquent`.',
+        )) {
+            info('Eloquent Driver installed. The file driver remains active.');
+
+            return;
+        }
+
         $success = spin(
             callback: fn () => $this->runArtisanCommand('seo:switch-to-eloquent --no-interaction'),
             message: 'Switching to Eloquent driver...',
         );
 
         $success
-            ? info('Eloquent Driver configured.')
+            ? info('Switched to the Eloquent driver and migrated existing SEO data successfully.')
             : warning('Failed to switch to Eloquent driver. Run `php artisan seo:switch-to-eloquent` manually.');
     }
 

--- a/tests/Commands/InstallTest.php
+++ b/tests/Commands/InstallTest.php
@@ -3,6 +3,7 @@
 use Aerni\AdvancedSeo\Tests\Concerns\FakesComposerLock;
 use Facades\Statamic\Console\Processes\Composer;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
 
 uses(FakesComposerLock::class);
 
@@ -28,4 +29,38 @@ it('enables redirects and installs simple-excel when selected', function () {
 
     expect(File::get(config_path('advanced-seo.php')))
         ->toMatch('/Disable to turn off redirect handling.*?\n.*?\n.*?\n.*?\n.*?\n.*?\'enabled\' => true/s');
+});
+
+it('installs the eloquent driver without switching when migration is declined', function () {
+    Composer::shouldReceive('isInstalled')->andReturnTrue();
+    Process::fake();
+
+    $this->artisan('seo:install')
+        ->expectsQuestion('Select the Pro features you would like to set up.', ['eloquent'])
+        ->expectsConfirmation('Would you like to switch to Eloquent and migrate your existing SEO data now?', 'no')
+        ->expectsQuestion('Select an addon to migrate from.', 'none')
+        ->assertExitCode(0);
+
+    Process::assertNothingRan();
+
+    expect(File::get(config_path('advanced-seo.php')))
+        ->toContain("'driver' => 'file'");
+});
+
+it('switches to eloquent and migrates when confirmed', function () {
+    Composer::shouldReceive('isInstalled')->andReturnTrue();
+    Process::fake();
+
+    $this->artisan('seo:install')
+        ->expectsQuestion('Select the Pro features you would like to set up.', ['eloquent'])
+        ->expectsConfirmation('Would you like to switch to Eloquent and migrate your existing SEO data now?', 'yes')
+        ->expectsQuestion('Select an addon to migrate from.', 'none')
+        ->assertExitCode(0);
+
+    Process::assertRan(fn ($process) => $process->command === [
+        PHP_BINARY,
+        defined('ARTISAN_BINARY') ? ARTISAN_BINARY : 'artisan',
+        'seo:switch-to-eloquent',
+        '--no-interaction',
+    ]);
 });


### PR DESCRIPTION
Selecting the Eloquent Driver during `seo:install` installed the package, switched the configured driver, and imported existing SEO data without asking. Installation now asks before switching and migrating, leaving the file driver active when declined. The success message confirms both operations when accepted.