### PR TITLE
Fix CP redirect errors crash when an error has no url

### DIFF
--- a/src/Http/Resources/Cp/Redirects/ListedError.php
+++ b/src/Http/Resources/Cp/Redirects/ListedError.php
@@ -22,12 +22,15 @@ class ListedError extends JsonResource
     public function toArray($request)
     {
         $error = $this->resource;
+        $url = $error->url();
 
-        $redirect = $this->matcher->match($error->url(), $error->site());
+        $redirect = is_string($url) && $url !== ''
+            ? $this->matcher->match($url, $error->site())
+            : null;
 
         return [
             'id' => $error->id(),
-            'url' => $error->url(),
+            'url' => $url,
             'hits' => $error->count(),
             'first_seen_at' => $error->firstSeenAtIso(),
             'last_seen_at' => $error->lastSeenAtIso(),

--- a/src/Redirects/RedirectErrorInbox.php
+++ b/src/Redirects/RedirectErrorInbox.php
@@ -40,7 +40,12 @@ class RedirectErrorInbox
         return RedirectFacade::errors()->query()
             ->where('site', $redirect->site())
             ->get()
-            ->filter(fn ($error) => RedirectPatternMatcher::matches($redirect->source(), $error->url()))
+            ->filter(function ($error) use ($redirect) {
+                $url = $error->url();
+
+                return is_string($url) && $url !== ''
+                    && RedirectPatternMatcher::matches($redirect->source(), $url);
+            })
             ->map->id()
             ->all();
     }

--- a/src/Redirects/RedirectErrorMatcher.php
+++ b/src/Redirects/RedirectErrorMatcher.php
@@ -50,8 +50,12 @@ class RedirectErrorMatcher
      * Return the redirect that covers the given error, preferring an enabled
      * redirect over a disabled one, or null when nothing matches.
      */
-    public function match(string $url, string $site): ?Redirect
+    public function match(?string $url, string $site): ?Redirect
     {
+        if (! is_string($url) || $url === '') {
+            return null;
+        }
+
         return $this->matchIn($url, $site, enabled: true)
             ?? $this->matchIn($url, $site, enabled: false);
     }

--- a/src/Redirects/RedirectPatternMatcher.php
+++ b/src/Redirects/RedirectPatternMatcher.php
@@ -18,8 +18,12 @@ class RedirectPatternMatcher
         return $pattern && @preg_match($pattern, $path, $matches) ? $matches : null;
     }
 
-    public static function matches(string $source, string $path): bool
+    public static function matches(string $source, ?string $path): bool
     {
+        if (! is_string($path) || $path === '') {
+            return false;
+        }
+
         if (RedirectSourceType::fromSource($source) === RedirectSourceType::Exact) {
             return Str::lower(static::normalizePath($source)) === Str::lower(static::normalizePath($path));
         }

--- a/src/Stache/Stores/RedirectErrorsStore.php
+++ b/src/Stache/Stores/RedirectErrorsStore.php
@@ -33,15 +33,21 @@ class RedirectErrorsStore extends BasicStore
     public function makeItemFromFile($path, $contents): RedirectError
     {
         $data = YAML::file($path)->parse();
+        $url = Arr::get($data, 'url');
 
-        return Redirect::errors()->make()
+        $error = Redirect::errors()->make()
             ->initialPath($path)
             ->id(pathinfo($path, PATHINFO_FILENAME))
-            ->url(Arr::get($data, 'url'))
             ->site(Arr::get($data, 'site'))
             ->count(Arr::get($data, 'count', 0))
             ->firstSeenAt(Arr::get($data, 'first_seen_at'))
             ->lastSeenAt(Arr::get($data, 'last_seen_at'));
+
+        if (is_string($url) && $url !== '') {
+            $error->url($url);
+        }
+
+        return $error;
     }
 
     public function deleteKeys(array $keys): void

--- a/tests/Http/Controllers/Cp/RedirectErrorControllerTest.php
+++ b/tests/Http/Controllers/Cp/RedirectErrorControllerTest.php
@@ -69,6 +69,21 @@ it('reports an error covered only by a disabled redirect as disabled', function 
     expect($response->json('data.0.redirect_url'))->not->toBeNull();
 });
 
+it('does not 500 when an error has a missing url', function () {
+    Redirect::errors()->make()->site('default')->count(1)->save();
+    Redirect::errors()->make()->url('/valid')->site('default')->count(1)->save();
+
+    $response = $this->actingAs($this->user)
+        ->getJson(cp_route('advanced-seo.redirects.errors.index').'?sort=url&order=asc')
+        ->assertOk();
+
+    $data = collect($response->json('data'));
+
+    expect($data->pluck('url'))->toContain(null)->toContain('/valid')
+        ->and($data->firstWhere('url', null)['status'])->toBe('unhandled')
+        ->and($data->firstWhere('url', null)['destination'])->toBeNull();
+});
+
 it('sorts by path ascending by default', function () {
     Redirect::errors()->make()->url('/charlie')->site('default')->count(1)->save();
     Redirect::errors()->make()->url('/alpha')->site('default')->count(1)->save();

--- a/tests/Redirects/RedirectErrorInboxTest.php
+++ b/tests/Redirects/RedirectErrorInboxTest.php
@@ -101,6 +101,15 @@ it('deletes when the redirect is gone', function () {
     expect(Redirect::errors()->findByUrl('/old', 'default'))->toBeNull();
 });
 
+it('does not treat an error with a missing url as handled', function () {
+    Redirect::errors()->make()->site('default')->save();
+    $redirect = Redirect::make()->source('/*')->destination('/new')->site('default');
+
+    app(RedirectErrorInbox::class)->deleteErrorsHandledBy($redirect);
+
+    expect(Redirect::errors()->query()->count())->toBe(1);
+});
+
 it('deleteHandledErrors removes errors handled by any enabled redirect on their site', function () {
     Event::fake([RedirectCreated::class, RedirectSaved::class]);
 

--- a/tests/Redirects/RedirectErrorMatcherTest.php
+++ b/tests/Redirects/RedirectErrorMatcherTest.php
@@ -73,6 +73,16 @@ it('treats an enabled gone redirect as handled despite having no destination', f
     expect(RedirectErrorMatcher::for(['default'])->match('/old', 'default')?->id())->toBe($redirect->id());
 });
 
+it('does not match a missing or empty url', function () {
+    tap(Redirect::make()->source('/old')->destination('/new')->site('default'))->save();
+    tap(Redirect::make()->source('/*')->destination('/catch')->site('default'))->save();
+
+    $matcher = RedirectErrorMatcher::for(['default']);
+
+    expect($matcher->match(null, 'default'))->toBeNull()
+        ->and($matcher->match('', 'default'))->toBeNull();
+});
+
 it('prefers the most specific pattern when several match', function () {
     tap(Redirect::make()->source('#^/blog/.+#')->destination('/regex')->site('default'))->save();
     $wildcard = tap(Redirect::make()->source('/blog/*')->destination('/wildcard/$1')->site('default'))->save();

--- a/tests/Redirects/RedirectPatternMatcherTest.php
+++ b/tests/Redirects/RedirectPatternMatcherTest.php
@@ -47,6 +47,13 @@ it('keeps regex sources case-sensitive unless the author opts in', function () {
         ->and(RedirectPatternMatcher::match('#^/Section$#i', '/section'))->toBe(['/section']);
 });
 
+it('does not match a missing or empty path', function () {
+    expect(RedirectPatternMatcher::matches('/old', null))->toBeFalse()
+        ->and(RedirectPatternMatcher::matches('/old', ''))->toBeFalse()
+        ->and(RedirectPatternMatcher::matches('/*', null))->toBeFalse()
+        ->and(RedirectPatternMatcher::matches('/*', ''))->toBeFalse();
+});
+
 it('matches an exact source case-insensitively', function () {
     expect(RedirectPatternMatcher::matches('/WP-Login.php', '/wp-login.php'))->toBeTrue()
         ->and(RedirectPatternMatcher::matches('/wp-login.php', '/about'))->toBeFalse();

--- a/tests/Stache/Stores/RedirectErrorsStoreTest.php
+++ b/tests/Stache/Stores/RedirectErrorsStoreTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use Aerni\AdvancedSeo\Contracts\RedirectError;
+use Aerni\AdvancedSeo\Stache\Stores\RedirectErrorsStore;
+use Facades\Statamic\Stache\Traverser;
+use Statamic\Stache\Stache;
+
+beforeEach(function (): void {
+    $this->files = app('files');
+    $this->files->ensureDirectoryExists(tempPath());
+
+    $this->store = (new RedirectErrorsStore(app(Stache::class), $this->files))->directory(tempPath());
+});
+
+afterEach(function (): void {
+    $this->files->deleteDirectory(tempPath());
+});
+
+it('includes only flat yaml files', function (): void {
+    $this->files->put(tempPath('abc.yaml'), '');
+    $this->files->put(tempPath('ignored.txt'), '');
+
+    $this->files->ensureDirectoryExists(tempPath('nested'));
+    $this->files->put(tempPath('nested/def.yaml'), '');
+
+    $files = Traverser::filter([$this->store, 'getItemFilter'])->traverse($this->store);
+
+    expect($files->keys()->all())->toBe([
+        tempPath('abc.yaml'),
+    ]);
+
+    expect(tempPath('ignored.txt'))->toBeFile()
+        ->and(tempPath('nested/def.yaml'))->toBeFile();
+});
+
+it('makes RedirectError instances from file', function (): void {
+    $path = tempPath('abc.yaml');
+
+    $this->files->put($path, <<<'YAML'
+url: /missing
+site: default
+count: 3
+first_seen_at: 1751450400
+last_seen_at: 1751450500
+YAML);
+
+    $item = $this->store->makeItemFromFile($path, $this->files->get($path));
+
+    expect($item)->toBeInstanceOf(RedirectError::class)
+        ->and($item->id())->toBe('abc')
+        ->and($item->url())->toBe('/missing')
+        ->and($item->site())->toBe('default')
+        ->and($item->count())->toBe(3)
+        ->and($item->firstSeenAt())->toBe(1751450400)
+        ->and($item->lastSeenAt())->toBe(1751450500);
+});
+
+it('hydrates yaml with a missing or null url', function (): void {
+    $missing = tempPath('missing.yaml');
+    $nullUrl = tempPath('null.yaml');
+
+    $this->files->put($missing, <<<'YAML'
+site: default
+count: 1
+YAML);
+
+    $this->files->put($nullUrl, <<<'YAML'
+url: ~
+site: default
+count: 1
+YAML);
+
+    expect($this->store->makeItemFromFile($missing, $this->files->get($missing))->url())->toBeNull()
+        ->and($this->store->makeItemFromFile($nullUrl, $this->files->get($nullUrl))->url())->toBeNull();
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Opening `/cp/advanced-seo/errors` (especially `sort=url&order=asc`) 500s with:

```
TypeError: RedirectErrorMatcher::match(): Argument #1 ($url) must be of type string, null given
```

from `ListedError::toArray()`. One record with a missing url takes down the whole listing because JSON-encoding the resource collection throws.

This is the leftover hole after #230. That PR added a global lock so concurrent 404 recording stops creating ghost Stache records (index entry, no file) that hydrate with a null url. It did not guard the listing: `ListedError` still passed `$error->url()` into `match(string $url)`. Leftover ghosts (or any yaml with no / null url) still crash the CP. Seen in production after #230 shipped.

## Fix

Defense in depth only — no change to the recording lock from #230.

- `RedirectErrorMatcher::match()` accepts `?string` and returns `null` for missing/empty urls (unmatched).
- `ListedError` does not pass a null/empty url into the matcher.
- `RedirectPatternMatcher::matches()` and `RedirectErrorInbox` skip the same hole so clearing handled errors cannot TypeError on a ghost.
- `RedirectErrorsStore` no longer calls the url setter with a missing/null yaml value.

Null-url items can still appear in the listing as unmatched so they can be deleted. Skipping them from the Stache index would not remove leftover index keys, and `getItemFilter` in this package is path-based.

## Tests

- CP listing with `sort=url&order=asc` and a null-url error returns 200, status `unhandled`.
- Matcher / pattern matcher / inbox do not treat a missing url as a match.
- Store hydrates yaml with a missing or `url: ~` as `null`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e89ba96d-9c44-41fe-a6ae-8d8abc7c583b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e89ba96d-9c44-41fe-a6ae-8d8abc7c583b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

